### PR TITLE
Automate triage issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest an idea for this project.
 title: ''
-labels: enhancement
+labels: ''
 assignees: ''
 ---
 

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,14 @@
+name: issue-automation
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: andymckay/labeler@master
+        with:
+          add-labels: 'triage'
+          ignore-if-labeled: true

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,10 +5,18 @@ on:
     types: [opened, labeled, unlabeled]
 
 jobs:
-  automate-issues-labels:
+  triage-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: andymckay/labeler@master
+      - name: If no labels, add triage
+        id: no-labels
+        uses: andymckay/labeler@master
+        if: ${{ join(github.event.issue.labels.*.name, ',') == "" }}
         with:
           add-labels: 'triage'
-          ignore-if-labeled: true
+
+      - name: If labeled, remove triage
+          uses: andymckay/labeler@master
+          if: ${{ steps.no-labels.outcome == "skipped" && join(github.event.issue.labels.*.name, ',') != "triage" }}
+          with:
+            remove-labels: 'triage'

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -16,7 +16,7 @@ jobs:
           add-labels: 'triage'
 
       - name: If labeled, remove triage
-          uses: andymckay/labeler@master
-          if: ${{ steps.no-labels.outcome == "skipped" && join(github.event.issue.labels.*.name, ',') != "triage" }}
-          with:
-            remove-labels: 'triage'
+        uses: andymckay/labeler@master
+        if: ${{ steps.no-labels.outcome == "skipped" && join(github.event.issue.labels.*.name, ',') != "triage" }}
+        with:
+          remove-labels: 'triage'


### PR DESCRIPTION
If no labels, add the `triage` label. Otherwise, check if there is a label other than `triage` and remove `triage` if it's been labeled.