### PR TITLE
Update DIAGNOSTIC_SEVERITY_RULES.md

### DIFF
--- a/DIAGNOSTIC_SEVERITY_RULES.md
+++ b/DIAGNOSTIC_SEVERITY_RULES.md
@@ -55,3 +55,5 @@ This doc details all available rules that can be customized using the `python.an
 | reportUnusedCallResult | Diagnostics for call expressions whose results are not consumed and are not None. |
 | reportUnsupportedDunderAll | Diagnostics for unsupported operations performed on `__all__`. |
 | reportUnusedCoroutine | Diagnostics for call expressions that return a Coroutine and whose results are not consumed. |
+| reportMissing imports | Import "pyPDF2" could not be resolved. |
+


### PR DESCRIPTION
Import "pyPDF2" could not be resolved. This is missing in my Visual studio code platform, despite already installed in my windows-cmd. Help!