### PR TITLE
CHANGELOG.md and DIAGNOSTIC_SEVERITY_RULES.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2022.9.21 (14 September 2022) PreRelease
+
+Notable changes:
+
+-   Bug Fix: Using `Concatenate` and `ParamSpec` leads to skipped parameter in signature help ([pylance-release#3275](https://github.com/microsoft/pylance-release/issues/3275))
+-   Bug Fix: Unexpected `reportMissingImports` in notebook for local package ([pylance-release#3208](https://github.com/microsoft/pylance-release/issues/3208))
+-   Experiment: New auto-indent approach using `formatOnType`. We'll be enabling this for a percentage of prerelease users in the near future ([pylance-release#1613](https://github.com/microsoft/pylance-release/issues/1613))
+
+Pylance's copy of Pyright has been updated from 1.1.270 to 1.1.271.
+
+-   See Pyright's release notes for details: [1.1.271](https://github.com/microsoft/pyright/releases/tag/1.1.271).
+
+## 2022.9.20 (14 September 2022) Release
+
+-   Release version that rolls up changes from the [2022.9.11](https://github.com/microsoft/pylance-release/blob/main/CHANGELOG.md#2022911-7-september-2022-prerelease) prerelease build.
+
 ## 2022.9.11 (7 September 2022) PreRelease
 
 Notable changes:

--- a/DIAGNOSTIC_SEVERITY_RULES.md
+++ b/DIAGNOSTIC_SEVERITY_RULES.md
@@ -29,6 +29,7 @@ This doc details all available rules that can be customized using the `python.an
 | reportUntypedBaseClass | Diagnostics for base classes whose type cannot be determined statically. These obscure the class type, defeating many type analysis features. |
 | reportUntypedNamedTuple | Diagnostics when “namedtuple” is used rather than “NamedTuple”. The former contains no type information, whereas the latter does. |
 | reportPrivateUsage | Diagnostics for incorrect usage of private or protected variables or functions. Protected class members begin with a single underscore `_` and can be accessed only by subclasses. Private class members begin with a double underscore but do not end in a double underscore and can be accessed only within the declaring class. Variables and functions declared outside of a class are considered private if their names start with either a single or double underscore, and they cannot be accessed outside of the declaring module. |
+| reportTypeCommentUsage | Diagnostics for `# type: xxx` comments for functions and variables. These are still supported for backward compatibility, but they are increasingly irrelevant and will likely be deprecated in the next few years. |
 | reportPrivateImportUsage | Diagnostics for incorrect usage of symbol imported from a "py.typed" module that is [not re-exported](https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface) from that module. |
 | reportConstantRedefinition | Diagnostics for attempts to redefine variables whose names are all-caps with underscores and numerals. |
 | reportIncompatibleMethodOverride | Diagnostics for methods that override a method of the same name in a base class in an incompatible manner (wrong number of parameters, incompatible parameter types, or incompatible return type). |
@@ -36,6 +37,7 @@ This doc details all available rules that can be customized using the `python.an
 | reportInconsistentConstructor | Diagnostics when an `__init__` method signature is inconsistent with a `__new__` signature. |
 | reportOverlappingOverload | Diagnostics for function overloads that overlap in signature and obscure each other or have incompatible return types. |
 | reportMissingSuperCall | Diagnostics for `__init__`, `__init_subclass__`, `__enter__` and `__exit__` methods in a subclass that fail to call through to the same-named method on a base class. |
+| reportUninitializedInstanceVariable | Diagnostics for instance variables that are not initialized in the class body or constructor |
 | reportInvalidStringEscapeSequence | Diagnostics for invalid escape sequences used within string literals. The Python specification indicates that such sequences will generate a syntax error in future versions. |
 | reportUnknownParameterType | Diagnostics for input or return parameters for functions or methods that have an unknown type. |
 | reportUnknownArgumentType | Diagnostics for call arguments for functions or methods that have an unknown type. |
@@ -57,8 +59,8 @@ This doc details all available rules that can be customized using the `python.an
 | reportUnboundVariable | Diagnostics for unbound and possibly unbound variables. |
 | reportInvalidStubStatement | Diagnostics for statements that should not appear within a stub file. |
 | reportIncompleteStub | Diagnostics for the use of a module-level `__getattr__` function, indicating that the stub is incomplete. | 
-| reportUnusedCallResult | Diagnostics for call expressions whose results are not consumed and are not None. |
 | reportUnsupportedDunderAll | Diagnostics for unsupported operations performed on `__all__`. |
+| reportUnusedCallResult | Diagnostics for call expressions whose results are not consumed and are not None. |
 | reportUnusedCoroutine | Diagnostics for call expressions that return a Coroutine and whose results are not consumed. |
 | reportUnusedExpression | Diagnostics for simple expressions whose results are not used in any way. The default value for this setting is 'none'. |
 | reportUnnecessaryTypeIgnoreComment | Diagnostics for a '# type: ignore' comment that would have no effect if removed. |


### PR DESCRIPTION
- Copied changelog.
- Added two missing diagnostics in DIAGNOSTIC_SEVERITY_RULES.md.
- Corrected order of one diagnostic.

Fix https://github.com/microsoft/pylance-release/issues/3339