### PR TITLE
Automate scrum board Triage column

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,6 +10,13 @@ jobs:
   triage-labels:
     runs-on: ubuntu-latest
     steps:
+      - name: If no labels, add to scrum board
+        uses: peter-evans/create-or-update-project-card@v2
+        if: ${{ join(github.event.issue.labels.*.name, ',') == '' }
+        with:
+          project-name: Python
+          column-name: Triage
+
       - name: If no labels, add triage
         id: no-labels
         uses: andymckay/labeler@master

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,7 +14,9 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v2
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
-          project-name: Python
+          token: ${{ secrets.PYLANCE_BOT_GITHUB_TOKEN }}
+          project-location: microsoft
+          project-number: 145
           column-name: Triage
 
       - name: If no labels, add triage

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,13 +10,6 @@ jobs:
   triage-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: If no labels, add to scrum board
-        uses: actions/add-to-project@v0.3.0
-        if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
-        with:
-          github-token: ${{ secrets.PROJECT_BOARD_ACTIONS_TOKEN }}
-          project-url: https://github.com/orgs/microsoft/projects/145/views/22
-
       - name: If no labels, add triage
         id: no-labels
         uses: andymckay/labeler@master
@@ -26,6 +19,13 @@ jobs:
 
       - name: If labeled, remove triage
         uses: andymckay/labeler@master
-        if: ${{ steps.no-labels.outcome == 'skipped' && join(github.event.issue.labels.*.name, ',') != 'triage' }}
+        if: ${{ steps.no-labels.outcome == 'skipped' && join(github.event.issue.labels.*.name, ',') != 'triage-needed' }}
         with:
           remove-labels: 'triage-needed'
+
+      - name: If triage-needed, add to scrum board
+        uses: actions/add-to-project@v0.3.0
+        if: ${{ steps.no-labels.outcome == 'success' }}
+        with:
+          github-token: ${{ secrets.PROJECT_BOARD_ACTIONS_TOKEN }}
+          project-url: https://github.com/orgs/microsoft/projects/145/views/17

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,8 +15,8 @@ jobs:
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
           token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}
-          project-location: microsoft
-          project-number: 145
+          project-location: debonte
+          project-number: 2
           column-name: Triage
 
       - name: If no labels, add triage

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,6 +14,7 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v2
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
+          token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}
           project-location: microsoft
           project-number: 145
           column-name: Triage

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,7 +15,7 @@ jobs:
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
           github-token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}
-          project-url: https://github.com/users/debonte/projects/2/views/1
+          project-url: https://github.com/orgs/microsoft/projects/145/views/22
 
       - name: If no labels, add triage
         id: no-labels

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: If no labels, add to scrum board
-        uses: actions/add-to-project@v1
+        uses: actions/add-to-project@v0.3.0
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
           github-token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -11,13 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: If no labels, add to scrum board
-        uses: peter-evans/create-or-update-project-card@v2
+        uses: actions/add-to-project@v1
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
-          token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}
-          project-location: debonte
-          project-number: 2
-          column-name: Triage
+          github-token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}
+          project-url: https://github.com/users/debonte/projects/2/views/1
 
       - name: If no labels, add triage
         id: no-labels

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,7 +14,6 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v2
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
-          token: ${{ secrets.PYLANCE_BOT_GITHUB_TOKEN }}
           project-location: microsoft
           project-number: 145
           column-name: Triage

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: If no labels, add to scrum board
         uses: peter-evans/create-or-update-project-card@v2
-        if: ${{ join(github.event.issue.labels.*.name, ',') == '' }
+        if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
           project-name: Python
           column-name: Triage

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/add-to-project@v0.3.0
         if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
         with:
-          github-token: ${{ secrets.ISSUE_ACTIONS_TOKEN }}
+          github-token: ${{ secrets.PROJECT_BOARD_ACTIONS_TOKEN }}
           project-url: https://github.com/orgs/microsoft/projects/145/views/22
 
       - name: If no labels, add triage


### PR DESCRIPTION
For https://github.com/microsoft/pyrx/issues/2802

Attempt at automatically adding new issues into the Triage column of the scrum board.

FYI, the `microsoft` org admins have [provided](https://github.com/microsoft/github-operations/issues/47) an org-level PAT named `PROJECT_BOARD_ACTIONS_TOKEN`. So we should be able to test this out now.