### PR TITLE
Docs on import hook-based editable installs (PEP 660)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -39,11 +39,11 @@ be taken as relative to the workspace root.
 
 Note that if you are coming to Pylance from using the Microsoft Python Language Server, this setting has changed from `python.autoComplete.extraPaths` to `python.analysis.extraPaths`.
 
-### Editable install packages not found
+### Editable install modules not found
 
-[PEP 660](https://peps.python.org/pep-0660/) enables build backends (ex. setuptools) to use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html) to the package source files rather than using a `.pth` file. Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pylance/Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pylance/Pyright will be unable to find the corresponding source files.
+[PEP 660](https://peps.python.org/pep-0660/) enables build backends (ex. setuptools) to use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html) to the package's source files rather than using a `.pth` file. Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pylance/Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pylance/Pyright will be unable to find the corresponding source files.
 
-If you want to use static analysis tooks and are willing to accept a lower fidelity editable install, you can configure your editable install to use `.pth` files instead of import hooks. See your build backend's documentation for details on how to do this. We have provided some basic information for common build backends below.
+If you want to use static analysis tools and you are willing to accept a lower-fidelity editable install, you can configure your editable install to use `.pth` files instead of import hooks. See your build backend's documentation for details on how to do this. We have provided some basic information for common build backends below.
 
 #### Setuptools
 Setuptools currently supports two ways to request ["compat mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior) where a `.pth` file will be used -- a config setting and an environment variable. Another option is ["strict mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs) which uses symlinks instead.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -39,6 +39,21 @@ be taken as relative to the workspace root.
 
 Note that if you are coming to Pylance from using the Microsoft Python Language Server, this setting has changed from `python.autoComplete.extraPaths` to `python.analysis.extraPaths`.
 
+### Editable install packages not found
+
+[PEP 660](https://peps.python.org/pep-0660/) enables build backends (ex. setuptools) to use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html) to the package source files rather than using a `.pth` file. Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pylance/Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pylance/Pyright will be unable to find the corresponding source files.
+
+If you want to use static analysis tooks and are willing to accept a lower fidelity editable install, you can configure your editable install to use `.pth` files instead of import hooks. See your build backend's documentation for details on how to do this. We have provided some basic information for common build backends below.
+
+#### Setuptools
+Setuptools currently supports two ways to request ["compat mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior) where a `.pth` file will be used -- a config setting and an environment variable. Another option is ["strict mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs) which uses symlinks instead.
+
+#### Hatch/Hatchling
+[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses `.pth` files by default. It uses import hooks if you set `dev-mode-exact` to `true`.
+
+#### PDM
+[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses `.pth` files by default. It uses import hooks if you set `editable-backend` to `"editables"`.
+
 ### Migrating from the Microsoft Python Language Server to Pylance
 
 If you are moving from the Microsoft Python Language Server over to Pylance, a good place to start is by reading [our migration doc](MIGRATING_TO_PYLANCE.md) which outlines a couple notable changes between the language servers.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -46,14 +46,14 @@ use import hooks to direct the [import machinery](https://docs.python.org/3/refe
 to the package's source files rather than using a `.pth` file. Import hooks can provide
 an editable installation that is a more accurate representation of your real installation.
 However, because resolving module locations using an import hook requires executing Python
-code, they are not usable by Pylance, Pyright, and other static analysis tools. Therefore,
-if your editable install is configured to use import hooks, Pylance/Pyright will be unable
-to find the corresponding source files.
+code, they are not usable by Pylance and other static analysis tools. Therefore, if your
+editable install is configured to use import hooks, Pylance will be unable to find the
+corresponding source files.
 
-If you want to use static analysis tools and you are willing to accept a lower-fidelity
-editable install, consider configuring your editable install to use `.pth` files instead
-of import hooks. See your build backend's documentation for details on how to do this. We
-have provided some basic information for common build backends below.
+If you want to use static analysis tools with an editable install, you should configure
+the editable install to use `.pth` files instead of import hooks. See your build backend's
+documentation for details on how to do this. We have provided some basic information for
+common build backends below.
 
 #### Setuptools
 Setuptools currently supports two ways to request

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -64,11 +64,12 @@ which uses symlinks instead.
 
 #### Hatch/Hatchling
 [Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses `.pth` files by
-default. It uses import hooks if you set `dev-mode-exact` to `true`.
+default. It will only use import hooks if you set `dev-mode-exact` to `true`.
 
 #### PDM
 [PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses `.pth`
-files by default. It uses import hooks if you set `editable-backend` to `"editables"`.
+files by default. It will only use import hooks if you set `editable-backend` to
+`"editables"`.
 
 ### Migrating from the Microsoft Python Language Server to Pylance
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -41,18 +41,34 @@ Note that if you are coming to Pylance from using the Microsoft Python Language 
 
 ### Editable install modules not found
 
-[PEP 660](https://peps.python.org/pep-0660/) enables build backends (ex. setuptools) to use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html) to the package's source files rather than using a `.pth` file. Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pylance/Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pylance/Pyright will be unable to find the corresponding source files.
+[PEP 660](https://peps.python.org/pep-0660/) enables build backends (ex. setuptools) to
+use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html)
+to the package's source files rather than using a `.pth` file. Import hooks can provide
+an editable installation that is a more accurate representation of your real installation.
+However, because resolving module locations using an import hook requires executing Python
+code, they are not usable by Pylance, Pyright, and other static analysis tools. Therefore,
+if your editable install is configured to use import hooks, Pylance/Pyright will be unable
+to find the corresponding source files.
 
-If you want to use static analysis tools and you are willing to accept a lower-fidelity editable install, you can configure your editable install to use `.pth` files instead of import hooks. See your build backend's documentation for details on how to do this. We have provided some basic information for common build backends below.
+If you want to use static analysis tools and you are willing to accept a lower-fidelity
+editable install, consider configuring your editable install to use `.pth` files instead
+of import hooks. See your build backend's documentation for details on how to do this. We
+have provided some basic information for common build backends below.
 
 #### Setuptools
-Setuptools currently supports two ways to request ["compat mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior) where a `.pth` file will be used -- a config setting and an environment variable. Another option is ["strict mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs) which uses symlinks instead.
+Setuptools currently supports two ways to request
+["compat mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior)
+where a `.pth` file will be used -- a config setting and an environment variable. Another
+option is ["strict mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs)
+which uses symlinks instead.
 
 #### Hatch/Hatchling
-[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses `.pth` files by default. It uses import hooks if you set `dev-mode-exact` to `true`.
+[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses `.pth` files by
+default. It uses import hooks if you set `dev-mode-exact` to `true`.
 
 #### PDM
-[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses `.pth` files by default. It uses import hooks if you set `editable-backend` to `"editables"`.
+[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses `.pth`
+files by default. It uses import hooks if you set `editable-backend` to `"editables"`.
 
 ### Migrating from the Microsoft Python Language Server to Pylance
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pylance-release/issues/3407

Added details in `TROUBLESHOOTING.md` on why import hook-based editable installs cause problems for Pylance/Pyright and how to configure some common build backends to use `.pth` files instead.

@erictraut, should we replicate this info in https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md? Or have a link between the docs in the two repos? Or?