### PR TITLE
Replace references to master branch with main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 <!--
 Read the guidelines for filing an issue first.
 
-https://github.com/microsoft/pylance-release/blob/master/TROUBLESHOOTING.md#filing-an-issue
+https://github.com/microsoft/pylance-release/blob/main/TROUBLESHOOTING.md#filing-an-issue
 -->
 
 ## Environment data

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Code contributions are welcomed via the [Pyright](https://github.com/microsoft/p
 
 Pylance ships with a collection of type stubs for popular modules to provide fast and accurate auto-completions and type checking. Our type stubs are sourced from [typeshed](https://github.com/python/typeshed) and our work-in-progress stub repository, [microsoft/python-type-stubs]( https://github.com/microsoft/python-type-stubs). Type stubs in microsoft/python-type-stubs will be contributed back to typeshed or added inline to source packages once they are of high enough quality.
 
-For information on getting started, refer to the [CONTRIBUTING instructions](https://github.com/microsoft/pyright/blob/master/CONTRIBUTING.md).
+For information on getting started, refer to the [CONTRIBUTING instructions](https://github.com/microsoft/pyright/blob/main/CONTRIBUTING.md).
 
 # Feedback
 


### PR DESCRIPTION
Noticed that `README.md` and `bug-report.md` still had URLs pointing to the master branch.