### PR TITLE
Remove project board automation

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -23,13 +23,6 @@ jobs:
         with:
           remove-labels: 'triage-needed'
 
-      - name: If triage-needed, add to scrum board
-        uses: actions/add-to-project@v0.3.0
-        if: ${{ steps.no-labels.outcome == 'success' }}
-        with:
-          github-token: ${{ secrets.PROJECT_BOARD_ACTIONS_TOKEN }}
-          project-url: https://github.com/orgs/microsoft/projects/145/views/17
-
   assignIssue:
     name: Assign Issue to Someone
     runs-on: ubuntu-latest


### PR DESCRIPTION
We're now automatically adding new pylance-release issues to the project board using the "Auto-add to project" workflow that GitHub recently shipped. https://github.com/orgs/microsoft/projects/145/workflows/6034473

Currently this approach only supports adding issues from a single repo. I chose pylance-release since that's where most of our issue traffic is. GitHub is planning to add support for watching multiple repos for issues: https://github.com/community/community/discussions/44816#discussioncomment-4731499

Our custom action is no longer needed and was broken anyway because the microsoft org admins were unwilling to continue giving us org-level access tokens.