### PR TITLE
Update round robin to use 'updated' for sorting

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -22,6 +22,7 @@ jobs:
             const issues = await github.rest.issues.listForRepo({
               state: 'all',
               assignee: '*',
+              sort: 'updated',
               owner: context.repo.owner,
               repo: context.repo.repo
             });


### PR DESCRIPTION
Since the validation only runs on an issue being created, 'updated' should list the last issue created whether it was new or transferred.

Fixes https://github.com/microsoft/pyrx/issues/3651