### PR TITLE
Remove `useLibraryCodeForTypes` from `USING_WITH_PYRIGHT.md`

### DIFF
--- a/USING_WITH_PYRIGHT.md
+++ b/USING_WITH_PYRIGHT.md
@@ -48,7 +48,6 @@ Both Pylance and Pyright have [settings](https://github.com/microsoft/pylance-re
 |----|----|----|----|----|
 | autoSearchPaths | true | false|  Adds 'src' to the list of search paths. | This may change what files are found when analyzing. So if you're getting missing imports for modules in your 'src' tree, this might be why. |
 | extraPaths | `PYTHONPATH` | [ ] | Additional search paths that will be used when searching for modules imported by files. | Pylance includes paths found in the `PYTHONPATH` environment variable and the `PYTHONPATH` definition from your [`.env` file](https://code.visualstudio.com/docs/python/environments#_environment-variable-definitions-file). Pyright ignores `.env` files and treats paths from the `PYTHONPATH` environment variable as third party library paths. This results in a difference in prioritization of these paths when resolving imports. |
-| useLibraryCodeForTypes | true | false | When true, 3rd party libraries are analyzed to produce type information. Without it, all 3rd party library types are assumed to be of type `Any` unless they provided type information explicitly. | This setting changes the types found by Pylance/Pyright and therefore can cause differences in errors reported, so make this the same for both if you want consistent results. A lot of the time this is the sole cause of differences. |
 | typeCheckingMode | off | basic | Determines what diagnostics are shown. | Pylance defaults to `off`, but there is a possibility that VS code will default this to `basic` for Pylance users. If you want to guarantee this is the same as Pyright, set it to `basic` (or whatever you want to enforce) by specifying it in your settings.json. |
 
 Here's an example `pyrightconfig.json` you would use to ensure Pylance and Pyright both picked up the same settings:
@@ -57,7 +56,6 @@ Here's an example `pyrightconfig.json` you would use to ensure Pylance and Pyrig
 {
     "autoSearchPaths": false,
     "extraPaths": [], // Include paths from PYTHONPATH env var and .env definition
-    "useLibraryCodeForTypes": false,
     "typeCheckingMode": "basic"
 }
 ```
@@ -68,7 +66,6 @@ or pyproject.toml
 [tool.pyright]
 autoSearchPaths=false
 extraPaths=[] # Include paths from PYTHONPATH env var and .env definition
-useLibraryCodeForTypes=false
 typeCheckingMode="basic"
 ```
 


### PR DESCRIPTION
`useLibraryCodeForTypes` defaults to `true` in Pyright now, so we no longer need to call it out as a Pylance/Pyright difference in `USING_WITH_PYRIGHT.md`.