### PR TITLE
Update latest-prerelease.json with pyright 1.1.339

### DIFF
--- a/releases/latest-prerelease.json
+++ b/releases/latest-prerelease.json
@@ -1,1 +1,1 @@
-{"pylanceVersion":"2023.12.103","pyrightVersion":"1.1.338"}
+{"pylanceVersion":"2023.12.103","pyrightVersion":"1.1.339"}


### PR DESCRIPTION
Pylance is outdated relative to pyright as I am getting alternating errors due to this issue https://github.com/microsoft/pyright/issues/6586

It was resolved in 1.1.339, would it be possible to have the latest prerelease updated to pyright 1.1.339?