### PR TITLE
Apply same filtering for round robin in pylance-release

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,7 +10,7 @@ jobs:
   assignIssue:
     name: Assign Issue to Someone
     runs-on: ubuntu-latest
-    if: github.repository == 'microsoft/pylance-release' && github.event.action == 'opened'
+    if: github.repository == 'microsoft/pylance-release' && github.event.action == 'opened' && && !contains( github.event.issue.labels.*.name, 'skip-reassign')
     steps:
       - name: Find last assigned
         id: assigned


### PR DESCRIPTION
Allow the use of the 'skip-reassign' label