### PR TITLE
Add erictraut as additional team member for closing issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,6 +31,7 @@ jobs:
         uses: ./actions/needs-more-info-closer
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          additionalTeam: "erictraut"
           label: waiting for user response
           # Close issues that are marked a 'waiting for user response' label and were last interacted with by a contributor or bot, after 30 days has passed.
           closeDays: 30


### PR DESCRIPTION
I noticed that https://github.com/microsoft/pylance-release/issues/5132 hasn't been closed by https://github.com/microsoft/pylance-release/blob/main/.github/workflows/stale.yml even though it hasn't gotten any comments since November 20.

Turns out that this is because the last comment is from Eric who is not a GitHub team member with the Write, Maintain, or Admin role, so the closer thinks that an external user has commented on the issue and leaves it open.

The `additionalTeam` parameter lets you add extra GitHub users whose comments should be ignored. See:
- https://github.com/microsoft/vscode-github-triage-actions/blob/stable/needs-more-info-closer/action.yml#L18
- https://github.com/microsoft/vscode-github-triage-actions/blob/stable/needs-more-info-closer/NeedsMoreInfoCloser.ts#L44

I'm leaving #5132 unchanged so after this is merged we can verify that it gets closed automatically.