### PR TITLE
Update "Close Stale Issues" workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,23 +4,23 @@ permissions:
   
 on:
   schedule:
-    #        ┌───────────── minute (0 - 59)
-    #        │ ┌───────────── hour (0 - 23)
-    #        │ │ ┌───────────── day of the month (1 - 31)
-    #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-    #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #        │ │ │ │ │
-    #        │ │ │ │ │
-    #        │ │ │ │ │
-    #        * * * * *
-    - cron: "0 0 * * *"
+    #       ┌───────────── minute (0 - 59)
+    #       │ ┌───────────── hour (0 - 23)
+    #       │ │ ┌───────────── day of the month (1 - 31)
+    #       │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #       │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    #       │ │ │ │ │
+    #       * * * * *
+    - cron: 20 11 * * * # 4:20am Redmond
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "microsoft/vscode-github-triage-actions"
           path: ./actions


### PR DESCRIPTION
It's been hitting the "exceed a secondary rate limit" issue over the past few days, but rerunning the action always works fine. 

The script is almost identical to [the one used in VSCode](https://github.com/microsoft/vscode/blob/main/.github/workflows/needs-more-info-closer.yml). I can't find out the exact cause, but I suspect that 5pm is a busy hour that might have too much traffic sending requests, so I am changing the schedule to be a less busy time. If it still doesn't work, I will consider adding the `retry-after` to the workflow. Also open to ideas.