### PR TITLE
Add comment in formatOnType to indicate autoIndent is set to 'none'

### DIFF
--- a/testing/single/.vscode/settings.json
+++ b/testing/single/.vscode/settings.json
@@ -17,5 +17,7 @@
     //    "source.unusedImports",
     //    "source.convertImportFormat"
     // ]
-    "python.analysis.extraPaths": ["${workspaceFolder:utfinname日本}"]
+    "python.analysis.extraPaths": [
+        "${workspaceFolder:utfinname日本}"
+    ],
 }

--- a/testing/single/.vscode/settings.json
+++ b/testing/single/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "editor.autoIndent": "none",
     "python.analysis.enablePytestSupport": true,
     "python.analysis.enablePytestExtra": true,
     "python.analysis.inlayHints.pytestParameters": true,

--- a/testing/single/.vscode/settings.json
+++ b/testing/single/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "editor.autoIndent": "none",
     "python.analysis.enablePytestSupport": true,
     "python.analysis.enablePytestExtra": true,
     "python.analysis.inlayHints.pytestParameters": true,

--- a/testing/single/src/formatOnType.py
+++ b/testing/single/src/formatOnType.py
@@ -1,5 +1,7 @@
 # you can trigger format on type by hitting enter at the end of statement
-# Run this test twice, once with "editor.autoIndent" set to the default and once with "editor.autoIndent" set to "none"
+# This test assumes `editor.autoIndent` is set to 'none'. This is to ensure
+# the outcomes described are consistent. If you want to do ad-hoc testing, you should
+# change this value back to the default.
 
 # place cursor after `:` and hit enter and confirm cursor is placed
 # at the expected indentation
@@ -22,12 +24,6 @@ if ch == "a":
     pass
     # type `:` after `else` and see `else` is moved to right position.
     else
-
-# place cursor in the middle of this comment
-# if autoIndent is set to none, new line should not have comment, else it should
-if True:
-    # Try the same with this comment.
-    pass
 
 # Set "autoFormatStrings" to true and add a { into the string below. Make sure
 # it auto adds the `f` on the front. Repeat for the other strings

--- a/testing/single/src/formatOnType.py
+++ b/testing/single/src/formatOnType.py
@@ -1,4 +1,5 @@
 # you can trigger format on type by hitting enter at the end of statement
+# Run this test twice, once with "editor.autoIndent" set to the default and once with "editor.autoIndent" set to "none"
 
 # place cursor after `:` and hit enter and confirm cursor is placed
 # at the expected indentation
@@ -21,7 +22,12 @@ if ch == "a":
     pass
     # type `:` after `else` and see `else` is moved to right position.
     else
-    
+
+# place cursor in the middle of this comment
+# if autoIndent is set to none, new line should not have comment, else it should
+if True:
+    # Try the same with this comment.
+    pass
 
 # Set "autoFormatStrings" to true and add a { into the string below. Make sure
 # it auto adds the `f` on the front. Repeat for the other strings


### PR DESCRIPTION
Not sure if this was on purpose, but it seems like we'd want to test with the defaults?