### PR TITLE
Simplify editable install docs

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -43,7 +43,7 @@ Note that if you are coming to Pylance from using the Microsoft Python Language 
 
 If you want to use static analysis tools with an editable install, you should configure the editable install to use `.pth` files that contain file paths rather than executable lines (prefixed with `import`) that install import hooks. See your package manager’s documentation for details on how to do this. We have provided some basic information for common package managers below.
 
-Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pyright will be unable to find the corresponding source files.
+Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pylance and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pylance will be unable to find the corresponding source files.
 
 #### pip / setuptools
 `pip` (`setuptools`) supports two ways to avoid import hooks:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -41,33 +41,21 @@ Note that if you are coming to Pylance from using the Microsoft Python Language 
 
 ### Editable install modules not found
 
-[PEP 660](https://peps.python.org/pep-0660/) enables build backends (ex. setuptools) to
-use import hooks to direct the [import machinery](https://docs.python.org/3/reference/import.html)
-to the package's source files rather than using a `.pth` file. Import hooks can provide
-an editable installation that is a more accurate representation of your real installation.
-However, because resolving module locations using an import hook requires executing Python
-code, they are not usable by Pylance and other static analysis tools. Therefore, if your
-editable install is configured to use import hooks, Pylance will be unable to find the
-corresponding source files.
+If you want to use static analysis tools with an editable install, you should configure the editable install to use `.pth` files that contain file paths rather than executable lines (prefixed with `import`) that install import hooks. See your package manager’s documentation for details on how to do this. We have provided some basic information for common package managers below.
 
-If you want to use static analysis tools with an editable install, you should configure
-the editable install to use `.pth` files instead of import hooks. See your build backend's
-documentation for details on how to do this. We have provided some basic information for
-common build backends below.
+Import hooks can provide an editable installation that is a more accurate representation of your real installation. However, because resolving module locations using an import hook requires executing Python code, they are not usable by Pyright and other static analysis tools. Therefore, if your editable install is configured to use import hooks, Pyright will be unable to find the corresponding source files.
 
-#### Setuptools
-Setuptools currently supports two ways to request
-["compat mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior)
-where a `.pth` file will be used -- a config setting and an environment variable. Another
-option is ["strict mode"](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs)
-which uses symlinks instead.
+#### pip / setuptools
+`pip` (`setuptools`) supports two ways to avoid import hooks:
+- [compat mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior)
+- [strict mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#strict-editable-installs)
 
-#### Hatch/Hatchling
-[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses `.pth` files by
+#### Hatch / Hatchling
+[Hatchling](https://hatch.pypa.io/latest/config/build/#dev-mode) uses path-based `.pth` files by
 default. It will only use import hooks if you set `dev-mode-exact` to `true`.
 
 #### PDM
-[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses `.pth`
+[PDM](https://pdm.fming.dev/latest/pyproject/build/#editable-build-backend) uses path-based `.pth`
 files by default. It will only use import hooks if you set `editable-backend` to
 `"editables"`.
 


### PR DESCRIPTION
[I revised Pyright's editable install docs](https://github.com/microsoft/pyright/pull/7643) back in April but neglected to update Pylance's docs to match.

This PR copies the editable install section from https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md#editable-installs with a small change to replace "Pyright" with "Pylance".

Btw, Eric recently mentioned [this mypy issue comment](https://github.com/python/mypy/issues/13392#issuecomment-2217077176) and was concerned that that meant that the workarounds we describe in this documentation would no longer work in recent versions of `pip`. However, that language was [added](https://github.com/pypa/setuptools/commit/8abf6dca26e00557bb4d32e25aaed27d1d00e3ef) to the `setuptools` documentation back in Feb 2023, so I don't believe there has been any recent behavior change in this area.