### PR TITLE
Fix latest-release and latest-prerelease manually

### DIFF
--- a/releases/latest-prerelease.json
+++ b/releases/latest-prerelease.json
@@ -1,1 +1,1 @@
-{"pylanceVersion":"2025.2.1","pyrightVersion":"1.1.393"}
+{"pylanceVersion":"2025.1.102","pyrightVersion":"1.1.393"}

--- a/releases/latest-release.json
+++ b/releases/latest-release.json
@@ -1,1 +1,1 @@
-{"pylanceVersion":"2024.12.1","pyrightVersion":"1.1.389"}
+{"pylanceVersion":"2025.2.1","pyrightVersion":"1.1.393"}


### PR DESCRIPTION
When we shipped 2025.2.1, `latest-prerelease.json` was updated instead of `latest-release.json`. I haven't investigated why yet. This PR fixes the files manually in the meantime so users of pyright-action and pyright-python get the expected behavior.

I noticed two other things while looking at these files:
1. Although `latest-release.json` should have been updated for 2025.2.1, I think technically updating `latest-prerelease.json` was correct since 2025.2.1 is the most recent release of any sort and includes everything that was in 2025.1.102 and potentially more. I'm not sure that's worth fixing though.
2. I saw that when we shipped the 2024.2.4 hotfix, `latest-release.json` got updated which was wrong. There's a version check in the logic that updates these files that should prevent it from overwriting a file with an older version, but apparently there's a bug there as well.
