### PR TITLE
Rename `needs repro` label to `team needs to reproduce`

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -49,7 +49,7 @@ jobs:
               repo: context.repo.repo,
               assignees: ['${{ steps.rotation.outputs.next }}']
             })
-      - name: Give it the label 'needs repro'
+      - name: Give it the label 'team needs to reproduce'
         uses: actions/github-script@v6.3.3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -58,7 +58,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['needs repro']
+              labels: ['team needs to reproduce']
             })
       - name: Save assignment to state
         uses: actions/github-script@v6.3.3


### PR DESCRIPTION
The phrasing "needs repro" seems to confuse a lot of users. They think the label is saying that there's missing info that we need them to provide.

I'll do the actual renaming of the label after merging this PR. I believe this is the only thing we need to change.