### PR TITLE
Update changelog 2025.4.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2025.4.100 (9 April 2025) PreRelease
+
+Notable changes:
+
+-   Enhancement: Invoke color picker with shortcut [pylance-release#6761](https://github.com/microsoft/pylance-release/issues/6761)
+-   Bug fix: Pylance crashes when there is a star import from a local module in `__builtins__.pyi` [pylance-release#7095](https://github.com/microsoft/pylance-release/issues/7095)
+
+Pylance's copy of Pyright has been updated from 1.1.398 to 1.1.399.
+
+-   See Pyright's release notes for details: [1.1.399](https://github.com/microsoft/pyright/releases/tag/1.1.399)
+
 ## 2025.4.1 (2 April 2025) Release
 
 Notable changes:

--- a/README.md
+++ b/README.md
@@ -67,18 +67,19 @@ Pylance provides users with the ability to customize their Python language suppo
         | python.analysis.includeAliasesFromUserFiles | false     | false      | true       |
         | python.analysis.functionReturnTypes       | false       | false      | true       |
         | python.analysis.pytestParameters          | false       | false      | true       |
-        | python.analysis.supportRestructuredText   | false       | false      | true       |
+        | python.analysis.supportRestructuredText   | false       | true       | true       |
         | python.analysis.supportDocstringTemplate  | false       | false      | true       |
+        | python.analysis.nodeExecutable            | ""          | ""         | "auto"     |
 
 - `python.analysis.typeCheckingMode`
     - Used to specify the level of type checking analysis performed.
     - Default: `off`. 
         > Note that the value of this setting can be overridden by having a pyrightconfig.json or a pyproject.toml. For more information see this [link](https://aka.ms/AArua4c).
     - Available values:
-        - `off`: No type checking analysis is conducted; unresolved imports/variables diagnostics are produced
-        - `basic`: All `off` rules + basic type checking rules
-        - `standard`: All `off` rules + basic type checking rules + standard type checking rules
-        - `strict`: All `off` rules + all type checking rules.
+        - `off`: No type checking analysis is conducted; unresolved imports/variables diagnostics are produced.
+        - `basic`: All rules from `off` + `basic` type checking rules.
+        - `standard`: All rules from `basic` + `standard` type checking rules.
+        - `strict`: All rules from `standard` + `strict` type checking rules.
         > You can refer to [pyright](https://microsoft.github.io/pyright/#/configuration?id=diagnostic-settings-defaults) documentation to reference the default type checking rules for each of the type checking modes.
     - Performance Consideration:
         - Setting `python.analysis.typeCheckingMode` to `off` can improve performance by disabling type checking analysis, which can be resource-intensive, especially in large codebases.
@@ -232,7 +233,7 @@ Pylance provides users with the ability to customize their Python language suppo
     - Performance Consideration:
         - Enabling this can impact performance by creating its own indices for standard libraries.
 
-- [`python.analysis.includeAliasFromUserFiles`](docs/settings/python_analysis_includeAliasesFromUserFiles.md)
+- [`python.analysis.includeAliasesFromUserFiles`](docs/settings/python_analysis_includeAliasesFromUserFiles.md)
     - Include alias symbols from user files. This will make alias symbols appear in features such as `add import` and `auto import`.
     - Default value: `false` (or `true` in `full` mode)
     - Accepted values:
@@ -415,15 +416,9 @@ Pylance provides users with the ability to customize their Python language suppo
         - `true`
         - `false` (default)
 
-- `python.analysis.enableNotebookDataTips`
-    - Enable data tips for the last value of a variable when executing notebook cells. 
-    - Accepted values:
-        - `true`
-        - `false` (default)
-
 - `python.analysis.diagnosticsSource`
     - Allows specifing a different language server to use for diagnostics. Pylance will combine its results with this other server.
-     - Accepted values:
+    - Accepted values:
         - `Pylance` (default)
         - `Pyright` - Allows running a different version of Pyright to generate diagnostics. See the `python.analysis.pyrightVersion` setting.
 
@@ -451,23 +446,26 @@ With semantic highlighting:
 
 Semantic colors can be customized in settings.json by associating the Pylance semantic token types and modifiers with the desired colors.
 
--   Semantic token types
+- Semantic token types
+    - class, enum
+    - parameter, variable, property, enumMember
+    - function, member
+    - module
+    - intrinsic
+    - magicFunction (dunder methods)
+    - selfParameter, clsParameter
 
-    -   class, enum
-    -   parameter, variable, property, enumMember
-    -   function, member
-    -   module
-    -   intrinsic
-    -   magicFunction (dunder methods)
-    -   selfParameter, clsParameter
+- Semantic token modifiers
+    - declaration
+    - readonly, static, abstract
+    - async
+    - typeHint, typeHintComment
+    - decorator
+    - builtin
+    - documentation
+    - overridden
+    - callable
 
--   Semantic token modifiers
-    -   declaration
-    -   readonly, static, abstract
-    -   async
-    -   typeHint, typeHintComment
-    -   decorator
-    -   builtin
 
 The [scope inspector](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#scope-inspector) tool allows you to explore what semantic tokens are present in a source file and what theme rules they match to.
 
@@ -494,11 +492,11 @@ Example of customizing semantic colors in settings.json:
 
 - `source.unusedImports`
 
-    -   Remove all unused imports in a file
+    - Remove all unused imports in a file
 
 - `source.convertImportFormat`
 
-    -   Convert import format according to `python.analysis.importFormat`.
+    - Convert import format according to `python.analysis.importFormat`.
 
 - `source.fixall.pylance`
     - Apply the commands listed in the `python.analysis.fixall` setting
@@ -513,14 +511,14 @@ Pylance leverages Microsoft's open-source static type checking tool, Pyright, to
 
 Code contributions are welcomed via the [Pyright](https://github.com/microsoft/pyright) repo.
 
-Pylance ships with a collection of type stubs for popular modules to provide fast and accurate auto-completions and type checking. Our type stubs are sourced from [typeshed](https://github.com/python/typeshed) and our work-in-progress stub repository, [microsoft/python-type-stubs]( https://github.com/microsoft/python-type-stubs). Type stubs in microsoft/python-type-stubs will be contributed back to typeshed or added inline to source packages once they are of high enough quality.
+Pylance ships with a collection of type stubs for popular modules to provide fast and accurate auto-completions and type checking. Our type stubs are sourced from [typeshed](https://github.com/python/typeshed) and our work-in-progress stub repository, [microsoft/python-type-stubs](https://github.com/microsoft/python-type-stubs). Type stubs in microsoft/python-type-stubs will be contributed back to typeshed or added inline to source packages once they are of high enough quality.
 
 For information on getting started, refer to the [CONTRIBUTING instructions](https://github.com/microsoft/pyright/blob/main/CONTRIBUTING.md).
 
 # Feedback
 
--   File a bug in [GitHub Issues](https://github.com/microsoft/pylance-release/issues/new/choose)
--   [Tweet us](https://twitter.com/pythonvscode/) with other feedback
+- File a bug in [GitHub Issues](https://github.com/microsoft/pylance-release/issues/new/choose)
+- [Tweet us](https://twitter.com/pythonvscode/) with other feedback
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,45 @@
-# Pylance
-
+Pylance
+=====================
 ### Fast, feature-rich language support for Python
 
 This repository is for providing feedback and documentation on the [Pylance language server extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) in Visual Studio Code. You can use the repository to report issues or submit feature requests. The Pylance codebase is not open-source but you can contribute to [Pyright](https://github.com/microsoft/pyright) to make improvements to the core typing engine that powers the Pylance experience.
 
-Pylance is the default language support for [Python in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and is shipped as part of that extension as an optional dependency.
+Pylance is the default language support for [Python in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and is shipped as part of that extension as an optional dependency. 
 
-# Quick Start
+The Pylance name is a small ode to Monty Python's Lancelot who was the first knight to answer the bridgekeeper's questions in the Holy Grail.
 
+Quick Start
+============
 1. Install the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) from the marketplace. Pylance will be installed as an optional extension.
 1. Open a Python (.py) file and the Pylance extension will activate.
 
 Note: If you've previously set a language server and want to try Pylance, make sure you've set `"python.languageServer": "Default" or "Pylance"` in your settings.json file using the text editor, or using the Settings Editor UI.
 
-# Features
+Features
+=========
 
 <img src=images/all-features.gif>
 
 Pylance provides some awesome features for Python 3, including:
 
--   Docstrings
--   Signature help, with type information
--   Parameter suggestions
--   Code completion
--   Auto-imports (as well as add and remove import code actions)
--   As-you-type reporting of code errors and warnings (diagnostics)
--   Code outline
--   Code navigation
--   Type checking mode
--   Native multi-root workspace support
--   IntelliCode compatibility
--   Jupyter Notebooks compatibility
--   Semantic highlighting
+* Docstrings
+* Signature help, with type information
+* Parameter suggestions
+* Code completion
+* Auto-imports (as well as add and remove import code actions)
+* As-you-type reporting of code errors and warnings (diagnostics)
+* Code outline
+* Code navigation
+* Type checking mode
+* Native multi-root workspace support
+* IntelliCode compatibility
+* Jupyter Notebooks compatibility
+* Semantic highlighting
 
 See the [changelog](CHANGELOG.md) for the latest release.
 
-# Settings and Customization
-
+Settings and Customization
+===============
 Pylance provides users with the ability to customize their Python language support via a host of settings which can either be placed in the `settings.json` file in your workspace, or edited through the Settings Editor UI. 
 
 - [`python.analysis.languageServerMode`](docs/settings/python_analysis_languageServerMode.md)
@@ -52,7 +55,7 @@ Pylance provides users with the ability to customize their Python language suppo
         - `full`: Designed for users seeking the most extensive feature set. This mode enables most of Pylance's features, offering the richest IntelliSense experience. Ideal for those who want access to the full range of available functionality.
     - Individual settings can be configured to override the defaults set by `languageServerMode`.
     - Default settings based on mode are:
-
+      
         | Mode                           | light      | default    | full       |
         | :----------------------------- | :--------- | :--------- | :--------- |
         | python.analysis.exclude                   | ["**"]      | []         | []         |
@@ -67,7 +70,7 @@ Pylance provides users with the ability to customize their Python language suppo
         | python.analysis.includeAliasesFromUserFiles | false     | false      | true       |
         | python.analysis.functionReturnTypes       | false       | false      | true       |
         | python.analysis.pytestParameters          | false       | false      | true       |
-        | python.analysis.supportRestructuredText   | false       | true       | true       |
+        | python.analysis.supportRestructuredText   | false       | true      | true       |
         | python.analysis.supportDocstringTemplate  | false       | false      | true       |
         | python.analysis.nodeExecutable            | ""          | ""         | "auto"     |
 
@@ -80,7 +83,7 @@ Pylance provides users with the ability to customize their Python language suppo
         - `basic`: All rules from `off` + `basic` type checking rules.
         - `standard`: All rules from `basic` + `standard` type checking rules.
         - `strict`: All rules from `standard` + `strict` type checking rules.
-        > You can refer to [pyright](https://microsoft.github.io/pyright/#/configuration?id=diagnostic-settings-defaults) documentation to reference the default type checking rules for each of the type checking modes.
+        > You can refer to [pyright](https://microsoft.github.io/pyright/#/configuration?id=diagnostic-settings-defaults) documentation to reference the default type checking rules for each of the type checking modes. 
     - Performance Consideration:
         - Setting `python.analysis.typeCheckingMode` to `off` can improve performance by disabling type checking analysis, which can be resource-intensive, especially in large codebases.
 
@@ -428,7 +431,9 @@ Pylance provides users with the ability to customize their Python language suppo
         - version string, i.e. `1.1.397`
         - path to a pyright-langserver.js file
 
-# Semantic highlighting
+
+Semantic highlighting
+=====================
 
 Visual Studio Code uses TextMate grammars as the main tokenization engine. TextMate grammars work on a single file as input and break it up based on lexical rules expressed in regular expressions.
 
@@ -466,16 +471,14 @@ Semantic colors can be customized in settings.json by associating the Pylance se
     - overridden
     - callable
 
-
-The [scope inspector](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#scope-inspector) tool allows you to explore what semantic tokens are present in a source file and what theme rules they match to.
+The [scope inspector](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#scope-inspector) tool allows you to explore what semantic tokens are present in a source file and what theme rules they match to. 
 
 Example of customizing semantic colors in settings.json:
 
 ```jsonc
 {
     "editor.semanticTokenColorCustomizations": {
-        "[One Dark Pro]": {
-            // Apply to this theme only
+        "[One Dark Pro]": { // Apply to this theme only
             "enabled": true,
             "rules": {
                 "magicFunction:python": "#ee0000",
@@ -488,26 +491,25 @@ Example of customizing semantic colors in settings.json:
     }
 }
 ```
-# Source Code Actions
 
+Source Code Actions
+===================
 - `source.unusedImports`
-
     - Remove all unused imports in a file
 
 - `source.convertImportFormat`
-
     - Convert import format according to `python.analysis.importFormat`.
 
 - `source.fixall.pylance`
     - Apply the commands listed in the `python.analysis.fixall` setting
 
-# Troubleshooting
-
+Troubleshooting
+===============
 Known issues are documented in [TROUBLESHOOTING](TROUBLESHOOTING.md).
 
-# Contributing
-
-Pylance leverages Microsoft's open-source static type checking tool, Pyright, to provide performant language support for Python.
+Contributing
+===============
+Pylance leverages Microsoft's open-source static type checking tool, Pyright, to provide performant language support for Python. 
 
 Code contributions are welcomed via the [Pyright](https://github.com/microsoft/pyright) repo.
 
@@ -515,10 +517,11 @@ Pylance ships with a collection of type stubs for popular modules to provide fas
 
 For information on getting started, refer to the [CONTRIBUTING instructions](https://github.com/microsoft/pyright/blob/main/CONTRIBUTING.md).
 
-# Feedback
 
-- File a bug in [GitHub Issues](https://github.com/microsoft/pylance-release/issues/new/choose)
-- [Tweet us](https://twitter.com/pythonvscode/) with other feedback
+Feedback
+===============
+* File a bug in [GitHub Issues](https://github.com/microsoft/pylance-release/issues/new/choose)
+* [Tweet us](https://twitter.com/pythonvscode/) with other feedback
 
 # License
 


### PR DESCRIPTION
Also updated `README.md`. There were a few content changes listed below, but most of the changes are formatting changes to get it closer to the extension README. At worst this makes them easier to compare and notice missing content in the pylance-release README. But perhaps we can get to the point where updating is automated.

- Updated `python.analysis.languageServerMode` table to correct `python.analysis.supportRestructuredText` default and add line for `python.analysis.nodeExecutable`.
- Corrected typo in name of `python.analysis.includeAliasesFromUserFiles`
- Remove `python.analysis.enableNotebookDataTips` which no longer exists.
- Added `documentation`, `overridden`, and `callable` to semantic token modifier list.