### PR TITLE
TROUBLESHOOTING.md: mention meson-python incompatibility with compat_…

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -69,6 +69,12 @@ default. It will only use import hooks if you set `dev-mode-exact` to `true`.
 files by default. It will only use import hooks if you set `editable-backend` to
 `"editables"`.
 
+#### meson-python
+
+Packages installed via [meson-python](https://meson-python.readthedocs.io/en/latest/) do **not** support `compat_mode=strict` or `compat_mode=compat`. 
+As a result, Pylance cannot resolve modules from editable installs made with meson-python. 
+This limitation is expected to persist, and users may encounter type checking issues with these packages.
+
 ### Migrating from the Microsoft Python Language Server to Pylance
 
 If you are moving from the Microsoft Python Language Server over to Pylance, a good place to start is by reading [our migration doc](MIGRATING_TO_PYLANCE.md) which outlines a couple notable changes between the language servers.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -71,9 +71,12 @@ files by default. It will only use import hooks if you set `editable-backend` to
 
 #### meson-python
 
-Packages installed via [meson-python](https://meson-python.readthedocs.io/en/latest/) do **not** support `compat_mode=strict` or `compat_mode=compat`. 
-As a result, Pylance cannot resolve modules from editable installs made with meson-python. 
-This limitation is expected to persist, and users may encounter type checking issues with these packages.
+Packages installed via [meson-python](https://meson-python.readthedocs.io/en/latest/) do **not** support `compat_mode=strict` or `compat_mode=compat`.  
+As a result, Pylance cannot resolve modules from editable installs made with meson-python.  
+
+As a workaround, users can manually add the package path to `python.analysis.extraPaths` in Pylance to help resolve imports. However, this requires manual configuration and does not fully replicate proper editable install behavior, so type checking issues may still occur.
+
+This limitation is expected to persist.
 
 ### Migrating from the Microsoft Python Language Server to Pylance
 


### PR DESCRIPTION
This PR updates TROUBLESHOOTING.md to include a note about meson-python and its limitations with editable installs. Users relying on meson-python may encounter unresolved import warnings in Pylance because this build system does not support compat_mode=strict or compat_mode=compat, unlike pip/setuptools.