### PR TITLE
docs(howto): add Copilot + Pylance MCP-tools workflow guides

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,21 +8,25 @@ This is the complete index of Pylance documentation. Use it to find guides, sett
 
 Step-by-step guides for common Pylance workflows and troubleshooting.
 
-| Guide                                                         | Description                                                                        |
-| ------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| [Auto-Import Guide](howto/auto-import-guide.md)               | Control auto-import suggestions: settings, indexing, and common issues             |
-| [CI Type Checking](howto/ci-type-checking.md)                 | Run Pyright in CI to enforce type checking                                         |
-| [Editable Installs](howto/editable-installs.md)               | Make `pip install -e` work with Pylance                                            |
-| [Generated Code](howto/generated-code.md)                     | Handle generated or dynamic code that Pylance cannot analyze statically            |
-| [Gradual Strict Adoption](howto/gradual-strict-adoption.md)   | Move from `off` to `strict` type checking incrementally                            |
-| [Monorepo Setup](howto/monorepo-setup.md)                     | Configure Pylance for monorepos, multi-root workspaces, and execution environments |
-| [Notebook Troubleshooting](howto/notebook-troubleshooting.md) | Fix common Pylance issues in Jupyter notebooks                                     |
-| [Performance Tuning](howto/performance-tuning.md)             | Reduce memory use and improve responsiveness                                       |
-| [Reading Pylance Logs](howto/reading-pylance-logs.md)         | Use trace logging to diagnose import resolution and settings                       |
-| [Remote Development](howto/remote-development.md)             | Use Pylance with SSH, WSL, containers, and Codespaces                              |
-| [Settings Troubleshooting](howto/settings-troubleshooting.md) | Diagnose settings precedence, config file overrides, and common conflicts          |
-| [Type Narrowing](howto/type-narrowing.md)                     | Use `isinstance`, `is None`, and type guards to fix type errors                    |
-| [Unresolved Imports](howto/unresolved-imports.md)             | Fix `reportMissingImports` and related import errors                               |
+| Guide                                                                               | Description                                                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [Auto-Import Guide](howto/auto-import-guide.md)                                     | Control auto-import suggestions: settings, indexing, and common issues                                       |
+| [CI Type Checking](howto/ci-type-checking.md)                                       | Run Pyright in CI to enforce type checking                                                                   |
+| [Copilot + Pylance Workflow](howto/copilot-pylance-workflow.md)                     | Use Pylance MCP tools with Copilot to diagnose and fix Python issues                                         |
+| [Dependency Management](howto/dependency-management.md)                             | Reconcile `requirements.txt`, `pyproject.toml`, lockfiles, and PEP 723 with what Pylance sees                |
+| [Editable Installs](howto/editable-installs.md)                                     | Make `pip install -e` work with Pylance                                                                      |
+| [Generated Code](howto/generated-code.md)                                           | Handle generated or dynamic code that Pylance cannot analyze statically                                      |
+| [Gradual Strict Adoption](howto/gradual-strict-adoption.md)                         | Move from `off` to `strict` type checking incrementally                                                      |
+| [Monorepo Setup](howto/monorepo-setup.md)                                           | Configure Pylance for monorepos, multi-root workspaces, and execution environments                           |
+| [Notebook Troubleshooting](howto/notebook-troubleshooting.md)                       | Fix common Pylance issues in Jupyter notebooks                                                               |
+| [Performance Tuning](howto/performance-tuning.md)                                   | Reduce memory use and improve responsiveness                                                                 |
+| [Python Environments](howto/python-environments.md)                                 | Pick the right interpreter, switch venvs, and handle multiple environments (`venv`, `conda`, `uv`, `poetry`) |
+| [Reading Pylance Logs](howto/reading-pylance-logs.md)                               | Use trace logging to diagnose import resolution and settings                                                 |
+| [Remote Development](howto/remote-development.md)                                   | Use Pylance with SSH, WSL, containers, and Codespaces                                                        |
+| [Settings Troubleshooting](howto/settings-troubleshooting.md)                       | Diagnose settings precedence, config file overrides, and common conflicts                                    |
+| [Type Narrowing](howto/type-narrowing.md)                                           | Use `isinstance`, `is None`, and type guards to fix type errors                                              |
+| [Unresolved Imports](howto/unresolved-imports.md)                                   | Fix `reportMissingImports` and related import errors                                                         |
+| [Workspace vs Open-Files Diagnostics](howto/workspace-vs-open-files-diagnostics.md) | Get errors across the whole workspace instead of only open files                                             |
 
 ---
 

--- a/docs/howto/copilot-pylance-workflow.md
+++ b/docs/howto/copilot-pylance-workflow.md
@@ -1,0 +1,239 @@
+# How to Fix Pylance Issues with Copilot
+
+Pylance ships a set of MCP tools that let GitHub Copilot (and any other MCP client) inspect your Python project the same way Pylance does in the editor: it can resolve interpreters, list user files, ask the language server for diagnostics, apply refactorings, and run code against the active environment.
+
+This guide is the canonical entry point for Copilot when fixing Pylance + VS Code problems. It maps common symptoms to the right tool, explains the order to call them in, and links out to topic-specific guides.
+
+The workflows here also work for humans driving Copilot Chat: ask Copilot to use a named tool, or ask it to "diagnose Pylance issues in this workspace" and let it pick.
+
+---
+
+## Table of Contents
+
+- [When to Use This Guide](#when-to-use-this-guide)
+- [Pylance MCP Tools at a Glance](#pylance-mcp-tools-at-a-glance)
+- [Standard Diagnosis Loop](#standard-diagnosis-loop)
+- [Symptom &rarr; Tool Map](#symptom--tool-map)
+- [Workflow Recipes](#workflow-recipes)
+    - [Verify the Active Environment and Workspace](#verify-the-active-environment-and-workspace)
+    - [Get Diagnostics for One File or the Whole Workspace](#get-diagnostics-for-one-file-or-the-whole-workspace)
+    - [Fix Unresolved Imports](#fix-unresolved-imports)
+    - [Remove Unused Imports and Run Fix-All](#remove-unused-imports-and-run-fix-all)
+    - [Resolve Type Errors](#resolve-type-errors)
+    - [Confirm a Hypothesis at Runtime](#confirm-a-hypothesis-at-runtime)
+- [Tool Call Conventions](#tool-call-conventions)
+- [What Copilot Should Not Do](#what-copilot-should-not-do)
+- [Related Guides](#related-guides)
+
+---
+
+## When to Use This Guide
+
+Use this workflow when any of the following is true:
+
+- Pylance shows unexpected errors, missing errors, or wrong import resolution.
+- Completions, hovers, or auto-imports are missing or wrong.
+- The wrong Python interpreter is selected, or multiple environments are involved.
+- You want Copilot to clean up imports, fix simple type errors, or apply other refactorings.
+- You want to confirm a static-analysis result against real runtime behavior.
+
+If the user only describes a symptom, Copilot should run [Standard Diagnosis Loop](#standard-diagnosis-loop) before suggesting fixes.
+
+---
+
+## Pylance MCP Tools at a Glance
+
+| Tool                                 | Use it to                                                                                                                        |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `pylanceDocuments`                   | Search and fetch Pylance how-to / settings / diagnostic docs (this guide and others).                                            |
+| `pylanceWorkspaceRoots`              | List workspace roots, or find the root that owns a given file.                                                                   |
+| `pylanceWorkspaceUserFiles`          | List the user Python files Pylance considers part of the workspace (after include/exclude).                                      |
+| `pylancePythonEnvironments`          | List discovered Python interpreters and which one is active per workspace root.                                                  |
+| `pylanceUpdatePythonEnvironment`     | Switch the active interpreter for a workspace root.                                                                              |
+| `pylanceSettings`                    | Inspect effective `python.analysis.*` settings for a workspace.                                                                  |
+| `pylanceFileSyntaxErrors`            | Quickly check parse errors in a single workspace file.                                                                           |
+| `pylanceSyntaxErrors`                | Parse-check an arbitrary code snippet without saving a file.                                                                     |
+| `pylanceLSP`                         | Issue read-only LSP requests: hover, completion, diagnostics (file or workspace), references, symbols, call/type hierarchy, etc. |
+| `pylanceImports`                     | List resolved and unresolved imports across the workspace.                                                                       |
+| `pylanceInstalledTopLevelModules`    | List top-level modules importable from the active environment.                                                                   |
+| `pylanceInvokeRefactoring`           | Apply automated refactorings (unused imports, fix-all, convert imports, add type annotations, etc.).                             |
+| `pylanceCheckSignatureCompatibility` | Verify that all callers of a function still match its current signature.                                                         |
+| `pylanceSemanticContext`             | Get rich semantic context (types, related snippets, dependencies) at a cursor position.                                          |
+| `pylanceRunCodeSnippet`              | Execute Python code against the workspace's active interpreter.                                                                  |
+| `pylancePythonDebug`                 | Launch the debugger to inspect runtime values, breakpoints, and stack frames.                                                    |
+
+These tools all operate against the same in-memory analysis Pylance is using in the editor, so their answers reflect the user's actual VS Code state, not a separate copy.
+
+---
+
+## Standard Diagnosis Loop
+
+When the user reports a Pylance problem, run this loop before guessing.
+
+1. **Ground the workspace.** Call `pylanceWorkspaceRoots` and `pylanceWorkspaceUserFiles` for the affected root. Confirm the workspace root URI and that the file Pylance is complaining about is actually a user file.
+2. **Confirm the interpreter.** Call `pylancePythonEnvironments` for the same root. Verify the active interpreter is the one the user expects (right venv, right Python version, right interpreter type).
+3. **Inspect settings.** Call `pylanceSettings`. Note any `python.analysis.*` settings that diverge from defaults, especially `extraPaths`, `include`, `exclude`, `diagnosticMode`, `typeCheckingMode`, `languageServerMode`, and `useLibraryCodeForTypes`.
+4. **Get diagnostics.** Call `pylanceLSP` with `textDocument/diagnostic` for the file in question, or `workspace/diagnostic` for the whole workspace. See [How to Get Whole-Workspace Diagnostics from Pylance](workspace-vs-open-files-diagnostics.md).
+5. **Confirm imports resolve.** If the issue smells like an import problem, call `pylanceImports` and `pylanceInstalledTopLevelModules`. See [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md).
+6. **Form a hypothesis, then act.** Apply the smallest fix (refactoring, settings change, environment switch). Re-run step 4 to confirm.
+
+Stop only when diagnostics either disappear or are explicitly accepted by the user.
+
+---
+
+## Symptom &rarr; Tool Map
+
+| Symptom                                                | Start with                                                                                                                                                                                 |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Import "X" could not be resolved`                     | `pylanceWorkspaceRoots` &rarr; `pylancePythonEnvironments` &rarr; `pylanceInstalledTopLevelModules` &rarr; `pylanceImports`. See [Unresolved Imports](unresolved-imports.md).              |
+| Wrong interpreter / wrong venv                         | `pylancePythonEnvironments` &rarr; `pylanceUpdatePythonEnvironment`. See [How to Choose a Python Environment for Pylance](python-environments.md).                                         |
+| "I only see errors for files I have open"              | `pylanceSettings` (check `diagnosticMode`) &rarr; `pylanceLSP` `workspace/diagnostic`. See [How to Get Whole-Workspace Diagnostics from Pylance](workspace-vs-open-files-diagnostics.md).  |
+| Unused imports / formatting cleanup                    | `pylanceInvokeRefactoring` (`source.unusedImports`, `source.fixAll.pylance`).                                                                                                              |
+| Wildcard import I want to expand                       | `pylanceInvokeRefactoring` (`source.convertImportStar`).                                                                                                                                   |
+| Need types added                                       | `pylanceInvokeRefactoring` (`source.addTypeAnnotation`).                                                                                                                                   |
+| Type error I do not understand                         | `pylanceLSP` (`textDocument/hover`, `textDocument/diagnostic`) &rarr; `pylanceSemanticContext` &rarr; optional `pylancePythonDebug` to confirm at runtime.                                 |
+| Missing dependency                                     | `pylanceInstalledTopLevelModules` &rarr; install via the user's package manager. See [How to Manage Python Dependencies for Pylance](dependency-management.md).                            |
+| Conflicting environments / multiple `requirements.txt` | `pylancePythonEnvironments` &rarr; [How to Choose a Python Environment for Pylance](python-environments.md) and [How to Manage Python Dependencies for Pylance](dependency-management.md). |
+| "Pylance does not seem to know about file X"           | `pylanceWorkspaceUserFiles` &rarr; `pylanceSettings` (check `include` / `exclude` / `pyrightconfig.json`).                                                                                 |
+| Editor settings change had no effect                   | `pylanceSettings`. See [How to Troubleshoot Pylance Settings](settings-troubleshooting.md).                                                                                                |
+
+---
+
+## Workflow Recipes
+
+### Verify the Active Environment and Workspace
+
+Always start here for any Pylance issue.
+
+1. `pylanceWorkspaceRoots` &mdash; with no arguments to list all roots, or with `fileUri` to find the root that owns a specific file.
+2. `pylancePythonEnvironments` for the relevant `workspaceRoot`.
+3. If the active interpreter is wrong, call `pylanceUpdatePythonEnvironment` with either an environment value returned by `pylancePythonEnvironments`, or the absolute path to a Python executable.
+4. Re-check diagnostics after switching &mdash; many Pylance "errors" are simply the wrong interpreter selected.
+
+See [How to Choose a Python Environment for Pylance](python-environments.md).
+
+### Get Diagnostics for One File or the Whole Workspace
+
+For a single file, prefer the LSP path because it returns the same diagnostics the editor shows:
+
+```jsonc
+// pylanceLSP
+{
+    "method": "textDocument/diagnostic",
+    "params": { "textDocument": { "uri": "file:///path/to/file.py" } },
+}
+```
+
+For the whole workspace, ask LSP directly. This works even when `python.analysis.diagnosticMode` is `"openFilesOnly"` because the LSP request targets all known files:
+
+```jsonc
+// pylanceLSP
+{
+    "method": "workspace/diagnostic",
+    "params": {},
+}
+```
+
+`pylanceFileSyntaxErrors` is a fast sanity check for parse errors in a single file (no type checking). `pylanceSyntaxErrors` does the same for an unsaved code snippet.
+
+See [How to Get Whole-Workspace Diagnostics from Pylance](workspace-vs-open-files-diagnostics.md).
+
+### Fix Unresolved Imports
+
+1. Confirm the interpreter with `pylancePythonEnvironments`.
+2. Call `pylanceInstalledTopLevelModules` for that environment to see whether the module is actually importable.
+3. Call `pylanceImports` to see what Pylance currently treats as resolved vs unresolved across the workspace.
+4. If the package is installed but Pylance does not see it, the issue is almost always one of:
+    - Wrong interpreter (fix with `pylanceUpdatePythonEnvironment`).
+    - Missing or wrong `extraPaths` / `include` (inspect with `pylanceSettings`).
+    - A `pyrightconfig.json` or `pyproject.toml` overriding VS Code settings.
+5. If the package is not installed, install it in the active environment using the user's package manager.
+
+See [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md), [How to Troubleshoot Pylance Settings](settings-troubleshooting.md), and [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md).
+
+### Remove Unused Imports and Run Fix-All
+
+`pylanceInvokeRefactoring` exposes the same source actions VS Code does, plus a few extras:
+
+- `source.unusedImports` &mdash; remove every unused `import` from a file.
+- `source.fixAll.pylance` &mdash; run every action listed in the `python.analysis.fixAll` array setting (a subset of `source.unusedImports`, `source.convertImportFormat`, `source.convertImportStar`, `source.addTypeAnnotation`). This is the same code action VS Code's `editor.codeActionsOnSave` invokes when the user opts into fix-on-save, but the two are configured independently &mdash; calling `source.fixAll.pylance` runs whatever is in `python.analysis.fixAll` regardless of any save-time configuration.
+- `source.convertImportFormat` &mdash; flip absolute &harr; relative imports per `python.analysis.importFormat`.
+- `source.convertImportStar` &mdash; expand `from x import *` into explicit names.
+- `source.convertImportToModule` &mdash; turn `from x import a, b` into `import x` plus qualified references.
+- `source.renameShadowedStdlibImports` &mdash; rename local modules that shadow stdlib names.
+- `source.addTypeAnnotation` &mdash; add inferred annotations to variables and functions.
+
+Each refactoring takes a single `fileUri` and an optional `mode`:
+
+- `mode: "edits"` returns a `WorkspaceEdit` without touching the editor. Useful for previewing or for "does this file actually need cleanup?" checks.
+- `mode: "string"` returns the rewritten file as text.
+- `mode: "update"` (default) applies a `WorkspaceEdit` to the editor. **It does not write to disk.** The change appears as an unsaved edit in the active editor. Copilot must explicitly save the file (for example by calling the host's save-file action) for the change to land on disk. Skipping the save step is a frequent source of "the refactoring did nothing" confusion.
+
+For multi-file cleanup, iterate `pylanceWorkspaceUserFiles`, call `pylanceInvokeRefactoring` per file, save each file, and then re-run `pylanceLSP` `workspace/diagnostic` to confirm.
+
+### Resolve Type Errors
+
+1. Get the exact diagnostic with `pylanceLSP` `textDocument/diagnostic`. Note the rule name (for example `reportArgumentType`).
+2. Read the rule page through `pylanceDocuments`: `path: "diagnostics/<reportName>.md"`. The rule page explains what triggers it and the canonical fixes.
+3. Use `pylanceLSP` `textDocument/hover` at the failing position to get the inferred types.
+4. Use `pylanceSemanticContext` for the position when you need surrounding code, base types, override sites, and project traits.
+5. Decide between, in order of preference:
+    1. **Fixing the code** so the types line up.
+    2. **Narrowing the type** with `isinstance`, `is None`, `assert`, or a type guard. See [How to Use Type Narrowing](type-narrowing.md).
+    3. **Adjusting annotations** (more precise input types, `TypeGuard`, `cast`, `assert_type`).
+    4. **Suppressing in source** for a single line that is genuinely correct but not provable. Two forms:
+        - `# type: ignore[ruleName]` &mdash; the standard typing-PEP comment, honored by Pylance and other type checkers.
+        - `# pyright: ignore[ruleName]` &mdash; Pyright/Pylance-specific. Prefer this when you only want to silence Pylance/Pyright and keep the diagnostic visible to other tools.
+          Always pin the rule name in brackets so the suppression does not also hide unrelated future errors. Add a brief comment explaining why the suppression is safe.
+    5. **Project-wide rule changes** via [`diagnosticSeverityOverrides`](../settings/python_analysis_diagnosticSeverityOverrides.md) or [`typeCheckingMode`](../settings/python_analysis_typeCheckingMode.md). Reserve this for rules that are genuinely wrong for the project, not for one-off failures.
+6. After editing, re-run `textDocument/diagnostic` for the same file.
+
+For changes to a function's signature, run `pylanceCheckSignatureCompatibility` at the function's name position to verify that all existing callers still match the new shape.
+
+### Confirm a Hypothesis at Runtime
+
+Static analysis is necessary but not sufficient. When a type error or unresolved import looks wrong, confirm with the actual interpreter:
+
+- `pylanceRunCodeSnippet` &mdash; run a short script against the active environment. Useful to check what is importable, what an object's type really is, or what an attribute resolves to.
+- `pylancePythonDebug` &mdash; launch the debugger, set breakpoints, and inspect values mid-execution. Use this when the bug only reproduces with real input.
+
+A common pattern: `pylanceLSP` says a value is `Optional[int]` and you do not believe it. Run a `pylanceRunCodeSnippet` that imports the module and prints `type(...)` to confirm. If runtime disagrees with static, the fix is usually a missing annotation, a missing stub, or a shadowing import &mdash; not a Pylance bug.
+
+---
+
+## Tool Call Conventions
+
+These conventions apply to every tool call:
+
+- `workspaceRoot` is a directory URI. On Windows the canonical form is `file:///c:/path/to/workspace` (lowercase drive letter, forward slashes).
+- `fileUri` is a file URI, for example `file:///c:/path/to/workspace/pkg/module.py`. Files outside any workspace root are typically rejected.
+- LSP `position` and `range` use 0-based `line` and `character`.
+- Pylance only reports user files; library and dependency files are excluded from diagnostics and from `pylanceWorkspaceUserFiles`.
+- Always pass an explicit `workspaceRoot` when the tool accepts one. Do not assume the current working directory.
+
+When in doubt, run `pylanceWorkspaceRoots` first to capture the canonical root URI, then reuse that string in subsequent calls.
+
+---
+
+## What Copilot Should Not Do
+
+- Do not infer the active interpreter from `which python` / `where python`. Use `pylancePythonEnvironments`.
+- Do not run `pip install` to "fix" an unresolved import without first confirming the active environment with `pylancePythonEnvironments`. Installing into the wrong environment will not change Pylance's behavior.
+- Do not blanket-suppress diagnostics with bare `# type: ignore` (no rule name) or [`diagnosticSeverityOverrides`](../settings/python_analysis_diagnosticSeverityOverrides.md) before understanding the rule. Read the rule page via `pylanceDocuments` first, and prefer rule-pinned suppressions like `# type: ignore[reportArgumentType]` or `# pyright: ignore[reportArgumentType]` when suppression is justified.
+- Do not assume `pylanceInvokeRefactoring` `mode: "update"` persists changes &mdash; it leaves the file dirty in the editor. Always save explicitly after editing, then re-check diagnostics.
+- Do not edit `pyrightconfig.json` or `pyproject.toml` to override VS Code settings unless the user asked for project-level configuration. Many `python.analysis.*` settings are silently ignored when a config file exists (see [How to Troubleshoot Pylance Settings](settings-troubleshooting.md)).
+- Do not assume `pylanceRunCodeSnippet` succeeded means the import will resolve in Pylance. The two paths can disagree when the runtime uses import hooks or `.pth` tricks. See [How to Use Editable Installs with Pylance](editable-installs.md).
+
+---
+
+## Related Guides
+
+- [How to Choose a Python Environment for Pylance](python-environments.md)
+- [How to Manage Python Dependencies for Pylance](dependency-management.md)
+- [How to Get Whole-Workspace Diagnostics from Pylance](workspace-vs-open-files-diagnostics.md)
+- [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md)
+- [How to Troubleshoot Pylance Settings](settings-troubleshooting.md)
+- [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md)
+- [How to Tune Pylance Performance](performance-tuning.md)
+- [How to Use Type Narrowing](type-narrowing.md)
+- [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md)

--- a/docs/howto/dependency-management.md
+++ b/docs/howto/dependency-management.md
@@ -1,0 +1,239 @@
+# How to Manage Python Dependencies for Pylance
+
+Pylance does not install packages. It only sees what is importable from the active Python interpreter. Most "missing dependency" complaints in the editor are really one of:
+
+- The dependency is not installed in the active environment.
+- It is installed, but in a different environment than the one Pylance is using.
+- It is installed but the project's dependency declarations are inconsistent across `requirements.txt`, `pyproject.toml`, lockfiles, and PEP 723 inline metadata.
+
+This guide explains how the common dependency declaration styles affect Pylance, how to inspect what Pylance currently sees, and how to keep declarations and the active environment in sync.
+
+---
+
+## Table of Contents
+
+- [How Pylance Sees Dependencies](#how-pylance-sees-dependencies)
+- [Inspect What Pylance Sees](#inspect-what-pylance-sees)
+- [Declaration Styles](#declaration-styles)
+    - [requirements.txt](#requirementstxt)
+    - [pyproject.toml](#pyprojecttoml)
+    - [Lockfiles](#lockfiles)
+    - [PEP 723 Inline Script Metadata](#pep-723-inline-script-metadata)
+- [Multiple requirements files](#multiple-requirements-files)
+- [Dependency Conflicts](#dependency-conflicts)
+- [Missing Type Information](#missing-type-information)
+- [Diagnostic Checklist](#diagnostic-checklist)
+- [FAQ](#faq)
+
+---
+
+## How Pylance Sees Dependencies
+
+Pylance treats a dependency as "available" only when it can resolve an import for it. That means:
+
+1. The package is installed under the active interpreter's `site-packages`, or somewhere on its `sys.path`.
+2. Or the package source is reachable via [`extraPaths`](../settings/python_analysis_extraPaths.md), `pyrightconfig.json` `extraPaths`, or an editable install.
+3. Or a stub-only package is installed (for example `types-requests`).
+
+Pylance does **not**:
+
+- Read `requirements.txt`, `pyproject.toml`, `Pipfile`, `poetry.lock`, or `uv.lock` to learn what should be installed.
+- Run `pip install` for you.
+- Honor `PYTHONPATH` from `.env` files in editor analysis (the Python extension may load `.env` for runtime, but Pylance's analysis search paths come from the interpreter and from `extraPaths`).
+
+Practical consequence: a project can be perfectly declared in `pyproject.toml` and still show import errors in the editor if you never installed the dependencies into the active environment.
+
+See [How to Choose a Python Environment for Pylance](python-environments.md) for picking the environment, and [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md) for unresolved-import triage.
+
+---
+
+## Inspect What Pylance Sees
+
+Before changing any declaration file, confirm reality.
+
+| Question                                  | How to answer it                                                                                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which interpreter is active?              | `pylancePythonEnvironments` for the workspace root.                                                                                         |
+| What is actually importable right now?    | `pylanceInstalledTopLevelModules` for the same workspace root. This lists top-level module names from the active environment.               |
+| Which imports across the project resolve? | `pylanceImports`. Returns resolved and unresolved imports per file across the workspace.                                                    |
+| What does the runtime say?                | `pylanceRunCodeSnippet` with `import sys, importlib; print(importlib.import_module("pkg").__file__)` &mdash; tells you the actual location. |
+| What are my effective settings?           | `pylanceSettings`. Watch for `extraPaths`, `useLibraryCodeForTypes`, and any overrides from `pyrightconfig.json`.                           |
+
+If `pylanceInstalledTopLevelModules` does not list the package, it is genuinely not installed in the active environment, regardless of what your `requirements.txt` says.
+
+---
+
+## Declaration Styles
+
+Different projects declare dependencies in different ways. They do not all behave the same in the editor.
+
+### requirements.txt
+
+A flat list of pinned (or unpinned) packages, typically installed with `pip install -r requirements.txt`.
+
+- **Pylance impact**: None directly. Pylance never reads this file. It only sees the result after `pip install` runs.
+- **Best for**: Simple deployments, CI pipelines, environments where you do not own the project metadata.
+- **Common pitfalls**:
+    - Multiple `requirements*.txt` files (`requirements.txt`, `requirements-dev.txt`, `requirements-test.txt`) often drift apart. The active environment may have only one of them installed, leaving editor errors for symbols defined in another.
+    - `-r requirements-other.txt` chaining is supported by `pip` but does not signal intent to Pylance.
+    - Unpinned versions can install a different release than CI uses, leading to type errors that only show up locally.
+
+If you use `requirements.txt`, install the union of every file you need analyzed and confirm with `pylanceInstalledTopLevelModules`.
+
+### pyproject.toml
+
+The modern standard (PEP 518 / PEP 621). Tools like `pip`, `uv`, `poetry`, and `hatch` install from it.
+
+```toml
+[project]
+name = "my-project"
+version = "0.1.0"
+dependencies = [
+    "requests>=2.31",
+    "pydantic>=2",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "ruff"]
+```
+
+- **Pylance impact**: None for `[project]` metadata directly. Pylance reads `[tool.pyright]` if present and ignores the rest of the file. See [How to Troubleshoot Pylance Settings](settings-troubleshooting.md).
+- **Best for**: Distributable libraries, tool-driven workflows.
+- **Common pitfalls**:
+    - Optional dependency groups (`pip install '.[dev]'`, `uv sync --all-extras`) must be installed explicitly. Forgetting `[dev]` is a frequent cause of "test framework not found" errors in the editor.
+    - Workspaces (`uv` workspaces, Poetry path dependencies) need an actual install step before Pylance sees the cross-package code, unless you use editable installs or [`extraPaths`](../settings/python_analysis_extraPaths.md). See [How to Use Editable Installs with Pylance](editable-installs.md).
+
+### Lockfiles
+
+`uv.lock`, `poetry.lock`, `Pipfile.lock` describe the exact versions resolved by the tool. They are inputs for the installer, not for Pylance.
+
+If the lockfile and the active environment disagree (for example you pulled a teammate's change to `uv.lock` but never ran `uv sync`), Pylance will show errors based on whatever is actually installed, not on the lockfile.
+
+A good habit when imports start failing after a `git pull`:
+
+1. Re-sync the environment (`uv sync`, `poetry install`, `pip install -r requirements.txt`, etc.).
+2. Confirm with `pylanceInstalledTopLevelModules`.
+3. Reload the window if necessary.
+
+### PEP 723 Inline Script Metadata
+
+[PEP 723](https://peps.python.org/pep-0723/) declares dependencies inline at the top of a single-file script:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "httpx>=0.27",
+#     "rich",
+# ]
+# ///
+
+import httpx
+from rich import print
+```
+
+`uv run script.py` (and similar runners) creates an ephemeral environment satisfying that block, then runs the script.
+
+Pylance impact:
+
+- Pylance does not currently treat PEP 723 metadata as input to import resolution. The editor will not magically resolve `httpx` just because the script declares it inline.
+- For an editor experience on PEP 723 scripts, point Pylance at a real environment that has those dependencies installed (for example a shared `.venv` you created with `uv pip install httpx rich`).
+- For runtime, `pylanceRunCodeSnippet` runs against the workspace's active interpreter. If you actually want PEP 723 resolution at runtime, invoke `uv run` from a terminal instead.
+
+---
+
+## Multiple requirements files
+
+Many projects keep separate files for different audiences:
+
+```text
+requirements.txt          # production
+requirements-dev.txt      # tests, linters
+requirements-docs.txt     # documentation toolchain
+```
+
+Pylance has no concept of "groups". It sees one active environment per workspace folder and asks "is this importable?". To get a clean editor experience:
+
+1. Decide which set of requirements is needed for the editor to be useful (usually production + dev).
+2. Install all of them into the active venv.
+3. Confirm with `pylanceInstalledTopLevelModules` that every package you need is present.
+
+If different parts of the project genuinely need different environments (for example a `dashboard/` subproject with its own dependencies that conflict with the parent), use a multi-root workspace and give each folder its own venv. See [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md) and [How to Choose a Python Environment for Pylance](python-environments.md).
+
+For the same project structured as a single workspace folder, you can also use [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) `executionEnvironments` to point different subdirectories at different `extraPaths` and Python versions, while still installing one combined environment.
+
+---
+
+## Dependency Conflicts
+
+Conflicts usually present in the editor as one of:
+
+- A package "disappears" after a fresh install (because a transitive resolver downgraded or removed it).
+- Imports resolve, but to an unexpected version (for example `pydantic` v1 features unavailable on a v2 install).
+- `pylanceRunCodeSnippet` and `pylanceLSP` disagree.
+
+Workflow:
+
+1. Confirm versions: `pylanceRunCodeSnippet` with `import pkg; print(pkg.__version__)`.
+2. Compare against the version expected by your declarations and lockfile.
+3. If they disagree, the environment is out of sync. Re-run the relevant install / sync command.
+4. If they agree but Pylance still complains, the issue is more likely a missing or wrong stub package &mdash; see [Missing Type Information](#missing-type-information).
+
+When two transitive dependencies require incompatible versions of a third, no editor setting will fix that. Resolve the conflict in your declaration file (pin a compatible version, drop a dependency, or split into two environments).
+
+---
+
+## Missing Type Information
+
+Pylance can sometimes resolve an import but show many `unknown` types or attribute errors for it. Common causes:
+
+| Cause                                                                                                              | Fix                                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Package is untyped (no `py.typed` marker, no inline annotations).                                                  | Install a stub package if available (`pip install types-requests`, `pip install types-PyYAML`, etc.).                                                                                                                                       |
+| Package is typed but [`useLibraryCodeForTypes`](../settings/python_analysis_useLibraryCodeForTypes.md) is `false`. | Enable it. `light` language server mode disables it by default &mdash; see [How to Tune Pylance Performance](performance-tuning.md).                                                                                                        |
+| Stubs you wrote locally are not picked up.                                                                         | Verify [`stubPath`](../settings/python_analysis_stubPath.md) points at the stub root (the directory containing per-package subdirectories), not at one specific package.                                                                    |
+| Stub-only package installed but the runtime package is missing.                                                    | You will get `reportMissingModuleSource`. Install the runtime package or suppress the rule. See [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md#import-could-not-be-resolved-from-source-reportmissingmodulesource). |
+
+For a wider tour of when to use `stubPath` vs `typeshedPaths` vs `useLibraryCodeForTypes`, see [How to Troubleshoot Pylance Settings](settings-troubleshooting.md).
+
+---
+
+## Diagnostic Checklist
+
+Use this when "missing dependency" complaints reach you:
+
+1. `pylanceWorkspaceRoots` &mdash; capture the canonical workspace root URI.
+2. `pylancePythonEnvironments` &mdash; confirm the active interpreter is the one the user expects.
+3. `pylanceInstalledTopLevelModules` &mdash; confirm the package is actually installed there.
+4. If not installed, install with the user's preferred package manager into that environment.
+5. If installed but Pylance does not resolve it, run `pylanceImports` and check `pylanceSettings` for `extraPaths` or a config-file override.
+6. If resolved but types are unknown, look for a stub package or change [`useLibraryCodeForTypes`](../settings/python_analysis_useLibraryCodeForTypes.md).
+7. Re-run `pylanceLSP` `textDocument/diagnostic` to confirm the error is gone.
+
+---
+
+## FAQ
+
+### Q: Pylance shows errors but `python script.py` runs fine. Who is right?
+
+Both are right about different things. The runtime ran whatever was on `sys.path` when you launched it. Pylance analyzed against its configured interpreter and search paths. If they disagree, the question is: which environment do you actually want the editor to reflect? Fix that one with [How to Choose a Python Environment for Pylance](python-environments.md).
+
+### Q: I added a dependency to `pyproject.toml`. Why does Pylance still flag the import?
+
+Adding the line does not install the package. Run your install/sync command (`uv sync`, `poetry install`, `pip install -e .[dev]`, etc.) and re-check `pylanceInstalledTopLevelModules`.
+
+### Q: Can Pylance use a `requirements.txt` to know what to install?
+
+No. Pylance never installs anything. The presence of `requirements.txt` is informational only.
+
+### Q: How do I pin the editor to the same Python version as production?
+
+The Python version comes from the selected interpreter. To pin the version independently of which interpreter the user happens to have, set `pythonVersion` in [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) (or under `[tool.pyright]` in `pyproject.toml`). Both Pylance and `pyright` honor it, which keeps the editor and CI in sync. See [How to Run Pyright in CI](ci-type-checking.md).
+
+### Q: Does Pylance support PEP 723 scripts?
+
+Pylance does not currently use PEP 723 inline metadata to extend its import-resolution search path. Scripts that rely on PEP 723 work fine when run with `uv run`, but for the editor experience point Pylance at a real environment that has the dependencies installed.
+
+### Q: How do I get Copilot to install a missing package?
+
+Copilot can read this guide via `pylanceDocuments` and use `pylancePythonEnvironments` to identify the environment, but it should not run `pip install` against the wrong one. Tell Copilot the workspace root, ask it to confirm the active environment, and only then install. See [How to Fix Pylance Issues with Copilot](copilot-pylance-workflow.md).

--- a/docs/howto/python-environments.md
+++ b/docs/howto/python-environments.md
@@ -1,0 +1,269 @@
+# How to Choose a Python Environment for Pylance
+
+Pylance resolves imports, infers types, and runs code analysis against a specific Python interpreter. If the wrong interpreter is selected, almost everything Pylance reports will be misleading: imports look broken, third-party types disappear, stdlib looks the wrong version, and `pip install` "does nothing".
+
+This guide explains how Pylance picks an interpreter, how to switch it correctly, and how to handle workspaces that contain multiple environments (`venv`, `virtualenv`, `conda`, `uv`, `poetry`, `pipenv`, system Python).
+
+---
+
+## Table of Contents
+
+- [How Pylance Picks an Interpreter](#how-pylance-picks-an-interpreter)
+- [How to Inspect and Change the Active Interpreter](#how-to-inspect-and-change-the-active-interpreter)
+- [Common Symptoms of a Wrong Interpreter](#common-symptoms-of-a-wrong-interpreter)
+- [Virtual Environments](#virtual-environments)
+- [Workspaces with Multiple Environments](#workspaces-with-multiple-environments)
+- [uv-Managed Environments](#uv-managed-environments)
+- [conda Environments](#conda-environments)
+- [Poetry, Pipenv, Hatch](#poetry-pipenv-hatch)
+- [Remote, WSL, and Container Environments](#remote-wsl-and-container-environments)
+- [Diagnostic Checklist](#diagnostic-checklist)
+- [FAQ](#faq)
+
+---
+
+## How Pylance Picks an Interpreter
+
+Pylance does not select interpreters on its own. It uses the interpreter chosen by the [Python extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-python.python).
+
+The Python extension picks an interpreter for each workspace folder using roughly this order, stopping at the first match:
+
+1. The interpreter explicitly chosen for the workspace (saved in `python.defaultInterpreterPath` or in workspace state).
+2. A virtual environment under the workspace folder (typical names: `.venv`, `venv`, `env`, `.env`).
+3. An environment named in tooling files in the folder, such as `.python-version` (`pyenv`), `pyproject.toml` (`poetry`, `hatch`), or `Pipfile` (`pipenv`).
+4. A `conda` environment recorded for the folder.
+5. The first Python interpreter discovered on `PATH`.
+
+Once selected, the interpreter:
+
+- Determines `sys.path` and the `site-packages` Pylance searches for third-party packages.
+- Determines the Python version Pylance assumes for type checking. Pylance derives the version from the interpreter itself. To pin the version independently of the interpreter, set `pythonVersion` in [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) (or `[tool.pyright]` in `pyproject.toml`).
+- Determines what `pylanceRunCodeSnippet` and `pylancePythonDebug` execute against.
+
+If the Python extension and Pylance disagree, Pylance loses. Always fix the Python extension's selection first.
+
+---
+
+## How to Inspect and Change the Active Interpreter
+
+There are three reliable ways to inspect or switch interpreters.
+
+### From the VS Code UI
+
+1. Click the Python version in the status bar.
+2. The interpreter quick pick lists detected environments.
+3. Pick one. The selection is persisted per workspace folder.
+
+If your environment is not listed:
+
+- Open the folder that contains the venv as a workspace folder, or
+- Run **Python: Select Interpreter** &rarr; **Enter interpreter path...** and provide the absolute path to `python` (or `python.exe`).
+
+### From settings
+
+Set `python.defaultInterpreterPath` in the appropriate scope. Workspace-folder scope wins:
+
+```jsonc
+// .vscode/settings.json
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+}
+```
+
+On Windows, prefer `.venv/Scripts/python.exe`.
+
+### From Copilot
+
+Copilot can see and change the interpreter through Pylance's MCP tools:
+
+- `pylancePythonEnvironments` &mdash; lists all discovered environments for a workspace root and marks which one is active.
+- `pylanceUpdatePythonEnvironment` &mdash; switches the active environment.
+
+`pylanceUpdatePythonEnvironment` accepts either a value returned by `pylancePythonEnvironments` or an absolute path to a Python executable. Pass the same `workspaceRoot` URI you got from `pylanceWorkspaceRoots`.
+
+After switching, re-check diagnostics with `pylanceLSP` `textDocument/diagnostic` or `workspace/diagnostic`. See [How to Fix Pylance Issues with Copilot](copilot-pylance-workflow.md).
+
+---
+
+## Common Symptoms of a Wrong Interpreter
+
+| Symptom                                                                  | Likely cause                                                                                                                                                 |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Every third-party `import` is unresolved.                                | Wrong interpreter, or no interpreter at all (system Python pointing at empty `site-packages`).                                                               |
+| `pip install` succeeds but Pylance still flags the import.               | `pip` and the active interpreter point at different environments.                                                                                            |
+| Stdlib types look wrong (for example `dict[str, int]` flagged as error). | Interpreter is older than expected, or `pythonVersion` in `pyrightconfig.json` / `[tool.pyright]` does not match the interpreter.                            |
+| Some files resolve imports, others do not.                               | Multi-root workspace with one folder pointing at the wrong interpreter. See [Workspaces with Multiple Environments](#workspaces-with-multiple-environments). |
+| `pylanceRunCodeSnippet` works but Pylance shows errors.                  | Common when the package is editable, uses import hooks, or relies on `.pth` files. See [How to Use Editable Installs with Pylance](editable-installs.md).    |
+| Tests that run fine in the terminal show import errors in the editor.    | The terminal is using a different shell-activated environment than the editor.                                                                               |
+
+A fast confirmation: run `pylanceRunCodeSnippet` with `import sys; print(sys.executable); print(sys.path)`. If that output does not match the interpreter you expected, the problem is interpreter selection, not Pylance.
+
+---
+
+## Virtual Environments
+
+A virtual environment is a self-contained directory with its own `python` binary and `site-packages`. It is the recommended way to isolate dependencies for a single project.
+
+Pylance treats venvs the same regardless of the tool that created them (`python -m venv`, `virtualenv`, `uv venv`, `poetry`, `hatch`, `pipenv`). The only thing Pylance cares about is the absolute path to the interpreter.
+
+Recommended layout:
+
+```text
+my-project/
+    .venv/                          # virtual environment
+        bin/python                  # Linux / macOS
+        Scripts/python.exe          # Windows
+    src/...
+    tests/...
+    pyproject.toml
+    .vscode/settings.json
+```
+
+Recommended workspace setting:
+
+```json
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+}
+```
+
+On Windows replace with `${workspaceFolder}/.venv/Scripts/python.exe`.
+
+Common pitfalls:
+
+- Activating the venv in a terminal does not affect the editor. The editor uses the configured interpreter, not whatever happens to be on `PATH` in your shell.
+- Deleting and recreating the venv leaves the editor pointing at a stale path until you reselect the interpreter.
+- A venv inside the workspace is auto-discovered. A venv outside the workspace must be added by absolute path.
+
+---
+
+## Workspaces with Multiple Environments
+
+A repository can contain multiple environments for legitimate reasons:
+
+- A monorepo where each package owns its own venv.
+- A project that ships a separate venv for build / automation tooling.
+- Mixed runtimes (for example a service in Python 3.11 plus a script in Python 3.13).
+
+Each VS Code workspace folder gets its own active interpreter. Pick the right strategy:
+
+| Setup                                                               | Recommendation                                                                                                                                                                                              |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One repo, one logical project, one venv.                            | Single-folder workspace. Pin the interpreter via `python.defaultInterpreterPath` in `.vscode/settings.json`.                                                                                                |
+| One repo, several packages, one shared venv.                        | Single-folder workspace plus [`extraPaths`](../settings/python_analysis_extraPaths.md) or editable installs to share code.                                                                                  |
+| One repo, several packages, several venvs.                          | Multi-root workspace (`.code-workspace`). Each folder picks its own interpreter. See [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md).                                                     |
+| Different Python versions for different parts.                      | Multi-root workspace, or use `executionEnvironments` in [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration). See [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md). |
+| Separate environment for tooling that must not pollute the project. | Keep the tooling env outside the workspace, or in an explicitly excluded folder.                                                                                                                            |
+
+When the same import appears resolved in one folder and unresolved in another, the cause is almost always per-folder interpreter selection or per-folder `extraPaths`. Inspect both sides with `pylancePythonEnvironments` and `pylanceSettings` before changing anything.
+
+---
+
+## uv-Managed Environments
+
+[`uv`](https://docs.astral.sh/uv/) manages environments and dependencies in a layout Pylance handles natively, because the resulting venv is just a regular venv.
+
+Typical setup:
+
+```bash
+uv venv .venv
+uv sync                  # if a pyproject.toml exists
+# or
+uv pip install -r requirements.txt
+```
+
+Then point Pylance at it the same as any other venv:
+
+```json
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+}
+```
+
+Notes specific to `uv`:
+
+- `uv run <script>` resolves dependencies in a managed environment. Running a script with `uv run` does not change which interpreter Pylance uses in the editor &mdash; you still need to select the matching environment via the Python extension.
+- `uv` supports [PEP 723 inline script metadata](dependency-management.md#pep-723-inline-script-metadata) for single-file scripts. Pylance does not currently parse PEP 723 metadata to add to its analysis search path; for an editor experience, point Pylance at a venv that has those dependencies installed.
+- `uv` can create environments in arbitrary locations (`uv venv --python 3.12 path/to/env`). Add such environments by absolute interpreter path.
+
+---
+
+## conda Environments
+
+`conda` and `mamba` environments are also detected by the Python extension. Pylance treats them as just another interpreter.
+
+Things to watch for:
+
+- A conda environment activated in a terminal does not change the editor's interpreter. Select it via **Python: Select Interpreter**.
+- Mixing `conda install` and `pip install` in the same environment can produce a `site-packages` layout where Pylance sees a package but `import` fails at runtime, or vice versa. Prefer one tool per environment.
+- For very large conda envs (data-science stacks), see [How to Tune Pylance Performance](performance-tuning.md).
+
+---
+
+## Poetry, Pipenv, Hatch
+
+`poetry`, `pipenv`, and `hatch` create venvs in tool-specific locations. Pylance still only needs the absolute path to the resulting `python` binary.
+
+| Tool     | Find the interpreter                                                                          |
+| -------- | --------------------------------------------------------------------------------------------- |
+| `poetry` | `poetry env info -p`, then append `/bin/python` (Linux/macOS) or `\Scripts\python.exe` (Win). |
+| `pipenv` | `pipenv --venv`, then append `/bin/python` or `\Scripts\python.exe`.                          |
+| `hatch`  | `hatch env find <env-name>`, then append `/bin/python` or `\Scripts\python.exe`.              |
+
+Either select that path through **Python: Select Interpreter** &rarr; **Enter interpreter path...** or pin it in `python.defaultInterpreterPath`.
+
+For `poetry`, see also [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md#q-how-do-i-set-up-a-poetry-monorepo).
+
+---
+
+## Remote, WSL, and Container Environments
+
+When VS Code is connected to a remote workspace (SSH, WSL, dev container, Codespace), Pylance runs in the remote environment. Interpreter selection still happens through the Python extension, but only environments that exist on the remote side are visible.
+
+Common gotchas:
+
+- A venv created on the local machine is not visible in WSL or in a container.
+- Mounted host paths can confuse interpreter discovery if the venv was built for a different OS.
+- For containers, prefer building the venv as part of the container image, or in a path that survives container rebuilds.
+
+See [How to Use Pylance in Remote Development](remote-development.md).
+
+---
+
+## Diagnostic Checklist
+
+When the user reports "Pylance is broken", run this checklist before changing anything:
+
+1. Get the active interpreter from `pylancePythonEnvironments`. Verify the path matches the user's expected venv.
+2. From `pylanceRunCodeSnippet`, confirm `sys.executable` and `sys.version`.
+3. From `pylanceInstalledTopLevelModules`, confirm the missing package is actually importable.
+4. From `pylanceSettings`, look for `python.defaultInterpreterPath`, `python.analysis.extraPaths`, and any `pyrightconfig.json` / `[tool.pyright]` overrides (including `pythonVersion`).
+5. Only then consider settings changes.
+
+---
+
+## FAQ
+
+### Q: Why does Pylance ignore the venv I activated in the terminal?
+
+The editor uses the interpreter selected by the Python extension. Terminal activation only affects new processes started from that terminal, not the language server. Select the interpreter through the UI or pin it in settings.
+
+### Q: I switched interpreters and Pylance still shows the old errors.
+
+Run **Developer: Reload Window** if diagnostics do not refresh after a switch. If you also changed `python.defaultInterpreterPath`, confirm with `pylancePythonEnvironments` that the new path is now active.
+
+### Q: Can Pylance use multiple interpreters in a single folder?
+
+Not directly. Each VS Code workspace folder gets one active interpreter. To analyze parts of the same folder under different Python versions or platforms, use `executionEnvironments` in [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration). See [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md#approach-3-execution-environments).
+
+### Q: Should I commit `.vscode/settings.json` with `python.defaultInterpreterPath`?
+
+Yes for relative paths under the workspace (`${workspaceFolder}/.venv/...`). Avoid committing absolute paths or user-specific locations &mdash; they will not work for other contributors.
+
+### Q: How do I make the editor and a CI run agree?
+
+CI typically does not use Pylance at all; it runs `pyright` (or another type checker) against a specific Python version. Match the editor's interpreter to the CI Python version, and prefer a project-level [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) with an explicit `pythonVersion` so both the editor and CI see the same configuration. See [How to Run Pyright in CI](ci-type-checking.md).
+
+### Q: How do I tell Copilot which environment to use?
+
+Tell Copilot the workspace root and let it run `pylancePythonEnvironments` &rarr; `pylanceUpdatePythonEnvironment`. You can also pass the absolute interpreter path directly. See [How to Fix Pylance Issues with Copilot](copilot-pylance-workflow.md).

--- a/docs/howto/workspace-vs-open-files-diagnostics.md
+++ b/docs/howto/workspace-vs-open-files-diagnostics.md
@@ -1,0 +1,186 @@
+# How to Get Whole-Workspace Diagnostics from Pylance
+
+By default Pylance only reports errors for files you have open. That keeps the editor responsive on large projects, but it surprises users who expect to see every error in the project at once. This guide explains the trade-off, when to widen scope, and how to get whole-workspace diagnostics on demand without permanently changing settings.
+
+---
+
+## Table of Contents
+
+- [Why You Only See Errors for Open Files](#why-you-only-see-errors-for-open-files)
+- [Pick the Right Approach](#pick-the-right-approach)
+- [Get Workspace Diagnostics On-Demand via LSP](#get-workspace-diagnostics-on-demand-via-lsp)
+- [Switch diagnosticMode to "workspace"](#switch-diagnosticmode-to-workspace)
+- [Run Pyright in CI](#run-pyright-in-ci)
+- [Confirm What Pylance Is Analyzing](#confirm-what-pylance-is-analyzing)
+- [Diagnostic Checklist](#diagnostic-checklist)
+- [FAQ](#faq)
+
+---
+
+## Why You Only See Errors for Open Files
+
+[`python.analysis.diagnosticMode`](../settings/python_analysis_diagnosticMode.md) controls which files Pylance actively reports diagnostics for in the editor.
+
+| Value                       | Behavior                                                                                                                                                                     |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"openFilesOnly"` (default) | Only files open in the editor produce diagnostics in the Problems panel and inline squiggles.                                                                                |
+| `"workspace"`               | All Python files in the workspace produce diagnostics, subject to [`include`](../settings/python_analysis_include.md) / [`exclude`](../settings/python_analysis_exclude.md). |
+
+Pylance still parses and indexes other files for completions, hovers, and import resolution. The setting only controls whether diagnostics are _published_ for them.
+
+The default is `"openFilesOnly"` because:
+
+- Whole-workspace diagnostics on large monorepos can use significant CPU and memory.
+- Most editing flows only care about the file you are touching.
+- CI is the right place to enforce errors across the whole project.
+
+See [How to Tune Pylance Performance](performance-tuning.md) for the full picture.
+
+---
+
+## Pick the Right Approach
+
+You have three ways to see errors outside the file you are editing. Pick by need:
+
+| You want to...                                                   | Use this                                                                                                    |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Quickly check the whole project once, without changing settings. | [Get Workspace Diagnostics On-Demand via LSP](#get-workspace-diagnostics-on-demand-via-lsp).                |
+| Continuously see all errors while editing.                       | [Switch diagnosticMode to "workspace"](#switch-diagnosticmode-to-workspace).                                |
+| Enforce errors as a build gate, independent of any editor state. | [Run Pyright in CI](#run-pyright-in-ci) (canonical guide: [How to Run Pyright in CI](ci-type-checking.md)). |
+
+The on-demand LSP path is the most common answer for "I want to know everything that is wrong right now without slowing down my editor".
+
+---
+
+## Get Workspace Diagnostics On-Demand via LSP
+
+The LSP `workspace/diagnostic` request asks the language server for diagnostics across all known files. It works regardless of `diagnosticMode`, because the request is explicit.
+
+### From Copilot or any MCP client
+
+Use the `pylanceLSP` MCP tool:
+
+```jsonc
+// pylanceLSP
+{
+    "method": "workspace/diagnostic",
+    "params": {},
+}
+```
+
+For a single file:
+
+```jsonc
+// pylanceLSP
+{
+    "method": "textDocument/diagnostic",
+    "params": { "textDocument": { "uri": "file:///path/to/file.py" } },
+}
+```
+
+These return the same diagnostics the editor would show, including type-check errors, unused imports, and other rules controlled by [`diagnosticSeverityOverrides`](../settings/python_analysis_diagnosticSeverityOverrides.md).
+
+A common workflow when investigating a Pylance-related complaint:
+
+1. `pylanceWorkspaceRoots` to capture the canonical root URI.
+2. `pylanceWorkspaceUserFiles` to confirm which files Pylance considers part of the workspace.
+3. `pylanceLSP` `workspace/diagnostic` to get every diagnostic at once.
+4. Group results by file and rule, then act.
+
+See [How to Fix Pylance Issues with Copilot](copilot-pylance-workflow.md) for the full diagnosis loop.
+
+### From the VS Code UI
+
+VS Code has no built-in command for "give me all workspace diagnostics" without changing settings. To force a one-shot full analysis you can either:
+
+- Open a representative set of files and let `openFilesOnly` produce diagnostics for them, or
+- Switch [`python.analysis.diagnosticMode`](../settings/python_analysis_diagnosticMode.md) to `"workspace"` temporarily, or
+- Run `pyright` from a terminal as a one-shot check.
+
+---
+
+## Switch diagnosticMode to "workspace"
+
+If you genuinely want full-project errors live in the editor, set:
+
+```json
+{
+    "python.analysis.diagnosticMode": "workspace"
+}
+```
+
+Things to know before flipping this on:
+
+- Initial analysis can be CPU- and memory-heavy on large workspaces. See [How to Tune Pylance Performance](performance-tuning.md).
+- The setting is honored per workspace folder. In a multi-root workspace you can enable it only where it matters.
+- Pair it with sensible [`include`](../settings/python_analysis_include.md) / [`exclude`](../settings/python_analysis_exclude.md) so test fixtures, vendored code, and generated outputs do not flood the Problems panel. See [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md) and [How to Handle Generated Code](generated-code.md).
+- For very large repos, prefer the on-demand LSP path or CI; do not leave `"workspace"` on permanently if it makes the editor sluggish.
+
+---
+
+## Run Pyright in CI
+
+Pylance is the editor; [`pyright`](https://github.com/microsoft/pyright) is the type checker that powers it. For build-gate enforcement, run `pyright` in CI rather than relying on a contributor's editor configuration.
+
+This is the right tool when you want:
+
+- A blocking check that everyone sees the same errors regardless of their VS Code settings.
+- A pinned Python version and pinned tool version.
+- Output that integrates with PR checks.
+
+Canonical guide: [How to Run Pyright in CI](ci-type-checking.md). For project-wide settings that both Pylance and `pyright` honor, prefer [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) over VS Code settings.
+
+---
+
+## Confirm What Pylance Is Analyzing
+
+If `workspace/diagnostic` returns fewer results than you expect, the issue is usually file scope, not the diagnostic mode.
+
+| Question                                                | How to answer it                                                                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Which files does Pylance treat as user files?           | `pylanceWorkspaceUserFiles` for the workspace root.                                                                 |
+| Are the missing files excluded by include / exclude?    | `pylanceSettings`. Look at `include`, `exclude`, `ignore`.                                                          |
+| Is a `pyrightconfig.json` overriding VS Code scope?     | See [How to Troubleshoot Pylance Settings](settings-troubleshooting.md).                                            |
+| Is the file even reachable from the active interpreter? | `pylanceImports` for the file in question; [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md). |
+
+Common gotchas:
+
+- Large auto-generated trees ignored by `exclude` will not produce diagnostics anywhere, regardless of `diagnosticMode`.
+- `include` defaults to the workspace root; if you set it explicitly to a subfolder, files outside that subfolder become invisible to diagnostics.
+- Files filtered out by [`userFileIndexingLimit`](../settings/python_analysis_userFileIndexingLimit.md) are still analyzed for diagnostics; the limit only affects indexing for auto-imports and symbol search. See [How to Tune Pylance Performance](performance-tuning.md).
+
+---
+
+## Diagnostic Checklist
+
+Use this when "Pylance is missing errors" is the complaint:
+
+1. Confirm `python.analysis.diagnosticMode` with `pylanceSettings`.
+2. Confirm the file is in `pylanceWorkspaceUserFiles`.
+3. Run `pylanceLSP` `workspace/diagnostic` (or `textDocument/diagnostic` for a single file) and inspect the result.
+4. If the expected errors are still missing, check `pylanceSettings` for `include` / `exclude`, [`typeCheckingMode`](../settings/python_analysis_typeCheckingMode.md), and any `pyrightconfig.json` overrides.
+5. If you only need a one-time sweep, prefer the LSP request over flipping the setting.
+
+---
+
+## FAQ
+
+### Q: Why do my errors disappear when I close the file?
+
+`openFilesOnly` only publishes diagnostics for currently open files. Closing the file removes its diagnostics from the Problems panel. The errors will reappear when you reopen the file. To see them continuously, switch to `"workspace"` or use `pylanceLSP` `workspace/diagnostic` on demand.
+
+### Q: Is `workspace/diagnostic` slower than the editor?
+
+It usually is on first call, because Pylance has to type-check files it had not analyzed yet. Subsequent calls are typically faster &mdash; the in-memory program retains analysis state for files that have not changed, so unchanged files do not need to be re-checked &mdash; but Pylance does not maintain a separate persisted cache of closed-file diagnostics, and any file change invalidates dependent results. For very large workspaces, prefer running [`pyright`](https://github.com/microsoft/pyright) in CI for build gating instead of repeatedly issuing `workspace/diagnostic`.
+
+### Q: Can I limit `workspace/diagnostic` to a folder?
+
+Not via the LSP request itself &mdash; it always covers the language server's view of the workspace. Limit scope by changing `include` / `exclude`, by opening a smaller folder as the workspace, or by running `pyright path/to/folder` from a terminal.
+
+### Q: I switched to `"workspace"` and the editor became unresponsive. What now?
+
+Switch back to `"openFilesOnly"` and either run `pylanceLSP` `workspace/diagnostic` on demand, or run `pyright` in a terminal. Tighten [`exclude`](../settings/python_analysis_exclude.md) to drop folders that should not be analyzed (vendored code, generated outputs, large test fixtures), and consider [`languageServerMode`](../settings/python_analysis_languageServerMode.md) `"light"` for very large workspaces. See [How to Tune Pylance Performance](performance-tuning.md). Note: [`userFileIndexingLimit`](../settings/python_analysis_userFileIndexingLimit.md) only affects indexing for auto-imports and symbol search, so it does not change the cost of `"workspace"` diagnostic mode.
+
+### Q: Should Copilot just flip `diagnosticMode` to `"workspace"` to see everything?
+
+No. The non-destructive answer is `pylanceLSP` `workspace/diagnostic`. Changing the user's settings should be an explicit ask, not a side effect of running a diagnosis. See [How to Fix Pylance Issues with Copilot](copilot-pylance-workflow.md).


### PR DESCRIPTION
## Summary

Adds four new how-to guides under `docs/howto/` aimed at users (and Copilot / any MCP client) who want to diagnose and fix Pylance issues using the Pylance MCP tools, and links them from `docs/INDEX.md`.

These pages are documentation-only and do not change product behavior.

## New pages

- **`howto/copilot-pylance-workflow.md`** — master entry point. Tools-at-a-glance table, standard diagnosis loop, symptom → tool map, workflow recipes (verify environment, get diagnostics, fix imports, remove unused, resolve type errors, confirm at runtime), tool-call conventions, and "what Copilot should not do".
- **`howto/python-environments.md`** — how Pylance picks an interpreter (it delegates to the Python extension), how to inspect and switch with `pylancePythonEnvironments` / `pylanceUpdatePythonEnvironment`, common wrong-interpreter symptoms, virtual environments, multi-environment workspaces, `uv` / `conda` / `poetry` / `pipenv` / `hatch`, remote / WSL / containers, FAQ.
- **`howto/dependency-management.md`** — how Pylance sees dependencies (only what is installed; it never reads `requirements.txt` or `pyproject.toml`), how to inspect with `pylanceInstalledTopLevelModules` / `pylanceImports`, declaration styles (`requirements.txt` vs `pyproject.toml` vs lockfiles vs PEP 723 inline metadata), multiple requirements files, dependency conflicts, missing type information, FAQ.
- **`howto/workspace-vs-open-files-diagnostics.md`** — why `diagnosticMode` defaults to `"openFilesOnly"`, on-demand workspace diagnostics via `pylanceLSP` `workspace/diagnostic`, when to switch to `"workspace"` mode, when to run `pyright` in CI, how to confirm what Pylance is analyzing, FAQ.

## Index

`docs/INDEX.md` "How-To Guides" table is regenerated alphabetically and gains four new rows for the pages above.

## Style notes

- All pages follow the existing how-to style (H1 "How to…", intro, TOC, tables, fenced code, `---` separators, FAQ).
- All cross-references use relative links to existing canonical pages (`unresolved-imports.md`, `settings-troubleshooting.md`, `monorepo-setup.md`, `performance-tuning.md`, `editable-installs.md`, `ci-type-checking.md`, `reading-pylance-logs.md`, `type-narrowing.md`, `generated-code.md`, `remote-development.md`, and `../settings/...` / `../diagnostics/...`).
- Generic and public-facing — no references to internal repos or paths.
- Verified behavior against the language server and `vscode-pylance/package.json`:
  - `pylanceInvokeRefactoring` `mode: "update"` applies a `WorkspaceEdit` that leaves the editor dirty; the file must be explicitly saved for the change to land on disk. The page calls this out so Copilot does not assume the change is persisted.
  - `source.fixAll.pylance` runs whatever is listed in the `python.analysis.fixAll` array setting; it is the action `editor.codeActionsOnSave` may invoke, but the two are configured independently.
  - Suppression guidance prefers rule-pinned `# type: ignore[ruleName]` / `# pyright: ignore[ruleName]` over bare `# type: ignore` or project-wide overrides.
  - Pythonversion pinning recommends `pythonVersion` in `pyrightconfig.json` / `[tool.pyright]` (no fictional `python.analysis.pythonVersion` setting).
  - `userFileIndexingLimit` is correctly described as affecting indexing for auto-imports / symbol search, not workspace-mode diagnostic cost.
