### PR TITLE
docs: clarify bundled stub precedence

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,7 @@ Step-by-step guides for common Pylance workflows and troubleshooting.
 | Guide                                                                               | Description                                                                                                  |
 | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | [Auto-Import Guide](howto/auto-import-guide.md)                                     | Control auto-import suggestions: settings, indexing, and common issues                                       |
+| [Bundled Third-Party Stubs](howto/bundled-stubs.md)                                  | Override bundled package stubs with workspace-local custom stubs                                             |
 | [CI Type Checking](howto/ci-type-checking.md)                                       | Run Pyright in CI to enforce type checking                                                                   |
 | [Copilot + Pylance Workflow](howto/copilot-pylance-workflow.md)                     | Use Pylance MCP tools with Copilot to diagnose and fix Python issues                                         |
 | [Dependency Management](howto/dependency-management.md)                             | Reconcile `requirements.txt`, `pyproject.toml`, lockfiles, and PEP 723 with what Pylance sees                |

--- a/docs/howto/bundled-stubs.md
+++ b/docs/howto/bundled-stubs.md
@@ -1,0 +1,149 @@
+# How to Override Bundled Third-Party Stubs in Pylance
+
+Pylance ships bundled type stubs for some popular third-party packages. These stubs improve IntelliSense and type checking when a package does not include its own type information.
+
+Bundled stubs are a fallback. If the bundled stub for a package is incomplete or does not match the version of the package you use, you can override it with workspace-local stubs through [`python.analysis.stubPath`](../settings/python_analysis_stubPath.md).
+
+---
+
+## When bundled stubs are used
+
+Pylance looks for imports in several places and stops at the first usable match. For third-party packages, the important order is:
+
+1. [`stubPath`](../settings/python_analysis_stubPath.md), which defaults to `typings`
+2. workspace source and [`extraPaths`](../settings/python_analysis_extraPaths.md)
+3. standard-library typeshed stubs
+4. installed packages from the selected interpreter, such as `site-packages`
+5. bundled third-party stubs
+6. typeshed third-party fallback stubs
+
+This means custom stubs in `stubPath` have higher priority than bundled stubs. Installed packages that provide type information through a `py.typed` marker also take priority over bundled stubs.
+
+For the complete import-resolution order, see [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md#how-pylance-resolves-imports). To inspect the order in your workspace, enable trace logging and see [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md).
+
+---
+
+## Use `typings` for a workspace-local override
+
+The default [`python.analysis.stubPath`](../settings/python_analysis_stubPath.md) value is `typings`. If you create a `typings` folder at the workspace root, Pylance checks it before bundled stubs.
+
+Use this when you need to patch one package for one workspace without replacing the full typeshed tree.
+
+```text
+my_project/
+├── .vscode/
+│   └── settings.json
+├── typings/
+│   └── examplelib-stubs/
+│       ├── __init__.pyi
+│       ├── py.typed
+│       └── api.pyi
+└── src/
+    └── app.py
+```
+
+If you use the default `typings` folder name, no setting is required. If you prefer another folder name, configure it explicitly:
+
+```json
+{
+    "python.analysis.stubPath": "custom_typings"
+}
+```
+
+---
+
+## Prefer partial stub packages for small patches
+
+For a small package-specific correction, a PEP 561 partial stub package is usually the safest shape. The folder name should end with `-stubs`, and its `py.typed` file should contain `partial`.
+
+Example:
+
+```text
+typings/
+└── examplelib-stubs/
+    ├── __init__.pyi
+    ├── py.typed
+    └── missing_module.pyi
+```
+
+`typings/examplelib-stubs/py.typed`:
+
+```text
+partial
+```
+
+This tells Pylance to use your stubs for the modules you provided while still allowing the installed package to supply the rest of the package surface.
+
+Use a partial stub package when you want to fill gaps. Use a full package stub, such as `typings/examplelib/...`, only when you intend your local stubs to describe the package surface completely.
+
+---
+
+## Example: patch a missing Django symbol
+
+Suppose your code imports a symbol that exists in your installed Django version, but Pylance reports it as missing because the bundled Django stub does not match your runtime package.
+
+Create a partial local stub package:
+
+```text
+typings/
+└── django-stubs/
+    ├── __init__.pyi
+    ├── py.typed
+    └── utils/
+        ├── __init__.pyi
+        └── deprecation.pyi
+```
+
+`typings/django-stubs/py.typed`:
+
+```text
+partial
+```
+
+`typings/django-stubs/utils/deprecation.pyi`:
+
+```python
+class RemovedInDjango50Warning(DeprecationWarning): ...
+class RemovedInDjango51Warning(PendingDeprecationWarning): ...
+```
+
+For the most accurate result, copy or adapt the declarations from a `django-stubs` package version that supports your Django version.
+
+---
+
+## Check which stub Pylance used
+
+Enable trace logging:
+
+```json
+{
+    "python.analysis.logLevel": "Trace"
+}
+```
+
+Then open **Output -> Pylance** and search for the module name. Helpful lines include:
+
+| Log Message | Meaning |
+| ----------- | ------- |
+| `Looking in stubPath '...'` | Pylance checked your workspace-local custom stubs. |
+| `Looking in python search path '...'` | Pylance checked installed packages from the selected interpreter. |
+| `Looking in bundled stubs path '...'` | Pylance checked bundled third-party stubs. |
+| `Resolved import with file '...'` | Pylance found the import at that path. |
+
+If the resolved path is under your workspace `typings` folder, your override is active.
+
+---
+
+## Should I use `stubPath` or `typeshedPaths`?
+
+Use [`python.analysis.stubPath`](../settings/python_analysis_stubPath.md) for package-specific fixes, including bundled third-party stub overrides.
+
+Use [`python.analysis.typeshedPaths`](../settings/python_analysis_typeshedPaths.md) only when you need to replace the typeshed source tree that Pylance consults for standard-library or typeshed fallback stubs.
+
+---
+
+## Related Guides
+
+- [Understanding `python.analysis.stubPath`](../settings/python_analysis_stubPath.md) - setting reference and directory layouts
+- [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md) - full import-resolution order and troubleshooting checklist
+- [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md) - trace logging and log interpretation

--- a/docs/howto/reading-pylance-logs.md
+++ b/docs/howto/reading-pylance-logs.md
@@ -42,7 +42,8 @@ Pylance tries these locations in order, stopping at the first match:
 | 3        | [`extraPaths`](../settings/python_analysis_extraPaths.md) entries    | `Looking in extraPath '...'`                               |
 | 4        | Typeshed stdlib stubs                                                | `Looking for typeshed stdlib path`                         |
 | 5        | Python interpreter search paths (`site-packages`)                    | `Looking in python search path '...'`                      |
-| 6        | Typeshed third-party stubs                                           | `Looking for typeshed third-party path`                    |
+| 6        | Bundled third-party stubs                                            | `Looking in bundled stubs path '...'`                      |
+| 7        | Typeshed third-party stubs                                           | `Looking for typeshed third-party path`                    |
 
 ---
 
@@ -55,6 +56,7 @@ Pylance tries these locations in order, stopping at the first match:
 | `Resolved import with file '...'`                | Pylance found the module. The path tells you _where_ it resolved to.               |
 | `Did not find file '...' or '...'`               | Exhausted options in that search location, trying the next.                        |
 | `Partially resolved import with directory '...'` | Found a directory but no `__init__.py` or module file.                             |
+| `Looking in bundled stubs path '...'`            | Pylance is checking bundled third-party stubs after installed packages.            |
 | `No python interpreter search path`              | Pylance has no site-packages path. Check that the correct interpreter is selected. |
 
 ### What to Look For
@@ -124,6 +126,7 @@ Search the Output panel (Ctrl+F) for the module name. The log lines include the 
 
 ## Related Guides
 
+- [How to Override Bundled Third-Party Stubs in Pylance](bundled-stubs.md) — use workspace-local stubs when bundled third-party stubs do not match your package version
 - [How to Fix Unresolved Import Errors in Pylance](unresolved-imports.md) — common import errors and their fixes
 - [How to Troubleshoot Pylance Settings](settings-troubleshooting.md) — settings precedence and config file interactions
 - [How to Set Up a Python Monorepo with Pylance](monorepo-setup.md) — cross-package import resolution in monorepos

--- a/docs/howto/unresolved-imports.md
+++ b/docs/howto/unresolved-imports.md
@@ -11,6 +11,7 @@ Pylance uses static analysis to resolve Python imports — it does not execute y
 - [Stub File Not Found (`reportMissingTypeStubs`)](#stub-file-not-found-reportmissingtypestubs)
 - [Circular Import Detected (`reportImportCycles`)](#circular-import-detected-reportimportcycles)
 - [Works at Runtime but Pylance Shows Errors](#works-at-runtime-but-pylance-shows-errors)
+- [Bundled Third-Party Stubs](#bundled-third-party-stubs)
 - [How Pylance Resolves Imports](#how-pylance-resolves-imports)
 - [Diagnostic Checklist](#diagnostic-checklist)
 - [FAQ](#faq)
@@ -233,24 +234,36 @@ Flask's app factory pattern uses `from app.extensions import db` which works at 
 
 ---
 
+## Bundled Third-Party Stubs
+
+Pylance includes bundled stubs for some popular third-party packages. These bundled stubs are used only after Pylance checks custom stubs, workspace paths, typeshed standard-library stubs, and installed packages from the selected interpreter.
+
+If a bundled third-party stub does not match the package version you use, add a workspace-local override through [`python.analysis.stubPath`](../settings/python_analysis_stubPath.md). The default stub directory is `typings`, and Pylance checks it before bundled stubs.
+
+For a package-specific patch, prefer a PEP 561 partial stub package under `typings`, such as `typings/package-stubs/py.typed` containing `partial`. See [How to Override Bundled Third-Party Stubs in Pylance](bundled-stubs.md) for examples.
+
+---
+
 ## How Pylance Resolves Imports
 
 Pylance searches for modules in a specific order, stopping at the first match:
 
-| Priority | Search Location                                                                                                                     | Notes                                |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| 1        | [`stubPath`](../settings/python_analysis_stubPath.md) (custom stubs)                                                                | Default: `./typings`                 |
-| 2        | Bundled type stubs (Pylance ships with stubs for popular packages)                                                                  | e.g., `django-stubs`, `pandas-stubs` |
-| 3        | Source files in the project root (or execution environment root)                                                                    | Your workspace files                 |
-| 4        | [`extraPaths`](../settings/python_analysis_extraPaths.md) entries                                                                   | Searched in order listed             |
-| 5        | `src/` directory (if [`autoSearchPaths`](../settings/python_analysis_autoSearchPaths.md) is `true` and `src/` has no `__init__.py`) | Automatic convenience path           |
-| 6        | Typeshed stdlib stubs                                                                                                               | Standard library type info           |
-| 7        | Python interpreter search paths (`site-packages`)                                                                                   | Third-party installed packages       |
-| 8        | Typeshed third-party stubs                                                                                                          | Community-maintained stubs           |
+| Priority | Search Location                                                                                                                     | Notes                                                  |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| 1        | [`stubPath`](../settings/python_analysis_stubPath.md) (custom stubs)                                                                | Default: `./typings`                                   |
+| 2        | Source files in the project root (or execution environment root)                                                                    | Your workspace files                                   |
+| 3        | [`extraPaths`](../settings/python_analysis_extraPaths.md) entries                                                                   | Searched in order listed                               |
+| 4        | `src/` directory (if [`autoSearchPaths`](../settings/python_analysis_autoSearchPaths.md) is `true` and `src/` has no `__init__.py`) | Automatic convenience path                             |
+| 5        | Typeshed stdlib stubs                                                                                                               | Standard library type info                             |
+| 6        | Python interpreter search paths (`site-packages`)                                                                                   | Installed packages from the selected interpreter       |
+| 7        | Bundled third-party stubs (Pylance ships with stubs for some popular packages)                                                      | Used when no earlier typed package or custom stub wins |
+| 8        | Typeshed third-party stubs                                                                                                          | Community-maintained fallback stubs                    |
 
 **Key implications**:
 
 - [`extraPaths`](../settings/python_analysis_extraPaths.md) entries have **higher priority** than installed packages in `site-packages`. This means workspace source code takes precedence over the same package installed from PyPI.
+- [`stubPath`](../settings/python_analysis_stubPath.md) has **higher priority** than bundled third-party stubs. Use it for workspace-local package-stub overrides.
+- Installed packages that include type information, such as a `py.typed` marker or installed stub package, take priority over bundled third-party stubs.
 - If [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) or `pyproject.toml` with `[tool.pyright]` exists, VS Code's [`python.analysis.extraPaths`](../settings/python_analysis_extraPaths.md) setting is **ignored** — use `"extraPaths"` in the config file instead. See [How to Troubleshoot Pylance Settings](settings-troubleshooting.md).
 
 ---
@@ -347,7 +360,7 @@ Enable trace logging and check the **Output → Pylance** panel:
 }
 ```
 
-The log shows each search location Pylance tries (stubPath → project root → extraPaths → typeshed → site-packages) and whether it resolved or failed. See [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md) for a detailed walkthrough.
+The log shows each search location Pylance tries, including `stubPath`, the project root, `extraPaths`, typeshed, `site-packages`, bundled third-party stubs, and third-party fallback stubs. See [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md) for a detailed walkthrough.
 
 ### Q: Auto-import suggests the wrong package path. How do I fix it?
 
@@ -424,6 +437,7 @@ def process(obj: HeavyClass) -> None:  # Pylance resolves this
 
 ## Related Guides
 
+- [How to Override Bundled Third-Party Stubs in Pylance](bundled-stubs.md) — override bundled package stubs with workspace-local custom stubs
 - [How to Use Editable Installs with Pylance](editable-installs.md) — build backend compatibility and `.pth` file troubleshooting
 - [How to Read Pylance Import Resolution Logs](reading-pylance-logs.md) — trace logging, search order, and log interpretation
 - [How to Troubleshoot Pylance Settings](settings-troubleshooting.md) — config file precedence and setting interactions

--- a/docs/settings/python_analysis_stubPath.md
+++ b/docs/settings/python_analysis_stubPath.md
@@ -18,6 +18,8 @@ The default value is `typings`.
 
 This default does not generate any stubs for you. It simply means Pylance looks for custom stubs in a workspace folder named `typings` if you create one.
 
+`stubPath` is the highest-priority package-stub location in Pylance's import resolution. It does not replace typeshed or other fallback stub sources; it lets you provide package-specific stubs that Pylance checks before workspace source, installed packages, bundled third-party stubs, and typeshed fallback stubs.
+
 ## When to use `stubPath`
 
 Use `python.analysis.stubPath` when you want to add or override type information for specific packages in your project.
@@ -28,6 +30,7 @@ Common cases include:
 - supplementing a third-party package that is missing some annotations
 - providing stubs for compiled extensions
 - correcting package-specific typing without replacing the full typeshed tree
+- overriding a bundled third-party stub that does not match the package version used by your workspace
 
 If you need to override the full typeshed source for standard-library or typeshed fallback stubs, use [`python.analysis.typeshedPaths`](python_analysis_typeshedPaths.md) instead.
 
@@ -136,6 +139,28 @@ With that structure, Pylance can merge the partial stub package with the install
 
 Use a partial stub package when you want to fill gaps. Use a regular full stub package when you want the stub package to define the package entirely.
 
+## Overriding bundled third-party stubs
+
+Pylance includes bundled stubs for some popular third-party packages. These bundled stubs are checked after the selected interpreter's installed packages and after `stubPath`.
+
+If a bundled stub is incomplete or stale for your package version, add a package-specific override under `stubPath`. For a small correction, prefer a partial stub package such as:
+
+```text
+typings/
+└── package-stubs/
+	├── __init__.pyi
+	├── py.typed
+	└── module.pyi
+```
+
+`typings/package-stubs/py.typed`:
+
+```text
+partial
+```
+
+For step-by-step examples, see [How to Override Bundled Third-Party Stubs in Pylance](../howto/bundled-stubs.md).
+
 ## How `stubPath` relates to `useLibraryCodeForTypes`
 
 If a library has weak or missing type information, a focused fix is often to add custom stubs through `python.analysis.stubPath` rather than disabling [`python.analysis.useLibraryCodeForTypes`](python_analysis_useLibraryCodeForTypes.md) for every library.
@@ -197,6 +222,8 @@ No. `python.analysis.stubPath` accepts a single directory path.
 
 No. It is for custom package stubs. It does not replace the full typeshed tree.
 
+It can override a bundled third-party stub for a specific package, because `stubPath` is checked before bundled third-party stubs. If you need to replace standard-library or typeshed fallback stubs, use [`python.analysis.typeshedPaths`](python_analysis_typeshedPaths.md) instead.
+
 ### Can I use an absolute path?
 
 Yes. You can use either an absolute path or a workspace-relative path.
@@ -216,6 +243,7 @@ Custom stubs provided through `stubPath` can resolve or suppress:
 
 ## See Also
 
+- [How to Override Bundled Third-Party Stubs in Pylance](../howto/bundled-stubs.md) — using `stubPath` for bundled-stub overrides
 - [How to Fix Unresolved Import Errors](../howto/unresolved-imports.md) — using custom stubs to resolve import errors
 - [How to Handle Generated Code](../howto/generated-code.md) — providing stubs for generated modules
 - [How to Set Up a Python Monorepo](../howto/monorepo-setup.md) — stub paths in multi-package projects


### PR DESCRIPTION
## Summary

- Add a bundled third-party stubs how-to that explains when bundled stubs are used and how to override them with `python.analysis.stubPath`.
- Correct the import-resolution order in the unresolved-imports guide so bundled third-party stubs are documented after installed packages.
- Add the bundled-stubs trace-log stage to the import-resolution logs guide.
- Expand the `stubPath` setting page to clarify package-specific overrides and the relationship to bundled stubs/typeshed.

Related to microsoft/pylance-release#6029.

## Validation

- `git diff --check`
- Relative Markdown link validation for touched files
- Local anchor validation for touched files