### PR TITLE
Update TSP docs and tsp.json to current protocol (0.4.1)

### DIFF
--- a/docs/tsp/tsp.json
+++ b/docs/tsp/tsp.json
@@ -4,29 +4,10 @@
     },
     "requests": [
         {
-            "method": "typeServer/getSnapshot",
-            "typeName": "GetSnapshotRequest",
-            "result": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "messageDirection": "clientToServer",
-            "documentation": "Request from client to get the current snapshot of the type server. A snapshot is a point-in-time representation of the type server's state, including all loaded files and their types."
-        },
-        {
-            "method": "typeServer/getSupportedProtocolVersion",
-            "typeName": "GetSupportedProtocolVersionRequest",
-            "result": {
-                "kind": "base",
-                "name": "string"
-            },
-            "messageDirection": "clientToServer",
-            "documentation": "Request to get the version of the protocol the type server supports. Returns a string representation of the protocol version (should be semver format)."
-        },
-        {
             "method": "typeServer/connection",
             "typeName": "ConnectionRequest",
             "messageDirection": "clientToServer",
+            "documentation": "Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic.",
             "params": {
                 "kind": "reference",
                 "name": "ConnectionRequestParams"
@@ -34,61 +15,43 @@
             "result": {
                 "kind": "reference",
                 "name": "ConnectionRequestResult"
-            },
-            "documentation": "Main-connection-only request used to open or close an extra TSP transport. Extra transports must remain read-only and must not be used for LSP traffic."
+            }
         },
         {
-            "method": "typeServer/getDiagnostics",
-            "typeName": "GetDiagnosticsRequest",
-            "result": {
-                "kind": "or",
-                "items": [
+            "method": "typeServer/getComputedType",
+            "typeName": "GetComputedTypeRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Requests and notifications for the type server protocol. Request for the computed type of a declaration or node. Computed type is the type that is inferred based on the code flow. Example: def foo(a: int | str): if instanceof(a, int): b = a + 1  # Computed type of 'b' is 'int'",
+            "params": {
+                "kind": "interface",
+                "properties": [
                     {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Diagnostic"
-                        }
+                        "name": "arg",
+                        "type": {
+                            "kind": "or",
+                            "items": [
+                                {
+                                    "kind": "reference",
+                                    "name": "Declaration"
+                                },
+                                {
+                                    "kind": "reference",
+                                    "name": "Node"
+                                }
+                            ]
+                        },
+                        "optional": false
                     },
                     {
-                        "kind": "base",
-                        "name": "null"
+                        "name": "snapshot",
+                        "type": {
+                            "kind": "base",
+                            "name": "number"
+                        },
+                        "optional": false
                     }
                 ]
             },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetDiagnosticsParams"
-            },
-            "documentation": "Request to get diagnostics for a specific file."
-        },
-        {
-            "method": "typeServer/getDiagnosticsVersion",
-            "typeName": "GetDiagnosticsVersionRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetDiagnosticsVersionParams"
-            },
-            "documentation": "Request to get the version of diagnostics for a specific file."
-        },
-        {
-            "method": "typeServer/getType",
-            "typeName": "GetTypeRequest",
             "result": {
                 "kind": "or",
                 "items": [
@@ -101,17 +64,43 @@
                         "name": "null"
                     }
                 ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetTypeParams"
-            },
-            "documentation": "Request to get the type information for a specific node."
+            }
         },
         {
-            "method": "typeServer/getBuiltinType",
-            "typeName": "GetBuiltinTypeRequest",
+            "method": "typeServer/getDeclaredType",
+            "typeName": "GetDeclaredTypeRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Request for the declared type of a declaration or node. Declared type is the type that is explicitly declared in the source code. Example: def foo(a: int | str): # Declared type of parameter 'a' is 'int | str' pass",
+            "params": {
+                "kind": "interface",
+                "properties": [
+                    {
+                        "name": "arg",
+                        "type": {
+                            "kind": "or",
+                            "items": [
+                                {
+                                    "kind": "reference",
+                                    "name": "Declaration"
+                                },
+                                {
+                                    "kind": "reference",
+                                    "name": "Node"
+                                }
+                            ]
+                        },
+                        "optional": false
+                    },
+                    {
+                        "name": "snapshot",
+                        "type": {
+                            "kind": "base",
+                            "name": "number"
+                        },
+                        "optional": false
+                    }
+                ]
+            },
             "result": {
                 "kind": "or",
                 "items": [
@@ -124,147 +113,43 @@
                         "name": "null"
                     }
                 ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetBuiltinTypeParams"
-            },
-            "documentation": "Request to get the type information for a specific builtin type."
+            }
         },
         {
-            "method": "typeServer/getTypeArgs",
-            "typeName": "GetTypeArgsRequest",
-            "result": {
-                "kind": "or",
-                "items": [
+            "method": "typeServer/getExpectedType",
+            "typeName": "GetExpectedTypeRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Request for the expected type of a declaration or node. Expected type is the type that the context expects. Example: def foo(a: int | str): pass foo(4)  # Expected type of argument 'a' is 'int | str'",
+            "params": {
+                "kind": "interface",
+                "properties": [
                     {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Type"
-                        }
+                        "name": "arg",
+                        "type": {
+                            "kind": "or",
+                            "items": [
+                                {
+                                    "kind": "reference",
+                                    "name": "Declaration"
+                                },
+                                {
+                                    "kind": "reference",
+                                    "name": "Node"
+                                }
+                            ]
+                        },
+                        "optional": false
                     },
                     {
-                        "kind": "base",
-                        "name": "null"
+                        "name": "snapshot",
+                        "type": {
+                            "kind": "base",
+                            "name": "number"
+                        },
+                        "optional": false
                     }
                 ]
             },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetTypeArgsParams"
-            },
-            "documentation": "Request to get the collection of subtypes that make up a union type or the types that makes up a generic type."
-        },
-        {
-            "method": "typeServer/getSymbolsForType",
-            "typeName": "GetSymbolsForTypeRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Symbol"
-                        }
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetSymbolsForTypeParams"
-            },
-            "documentation": "Request to find symbols from a type."
-        },
-        {
-            "method": "typeServer/getSymbolsForNode",
-            "typeName": "GetSymbolsForNodeRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Symbol"
-                        }
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetSymbolsForNodeParams"
-            },
-            "documentation": "Request to find symbols from a node."
-        },
-        {
-            "method": "typeServer/getOverloads",
-            "typeName": "GetOverloadsRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Type"
-                        }
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetOverloadsParams"
-            },
-            "documentation": "Request to get all overloads of a function or method. The returned value doesn't include the implementation signature."
-        },
-        {
-            "method": "typeServer/getMatchingOverloads",
-            "typeName": "GetMatchingOverloadsRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Type"
-                        }
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetMatchingOverloadsParams"
-            },
-            "documentation": "Request to get the overloads that a call node matches."
-        },
-        {
-            "method": "typeServer/getMetaclass",
-            "typeName": "GetMetaclassRequest",
             "result": {
                 "kind": "or",
                 "items": [
@@ -277,201 +162,17 @@
                         "name": "null"
                     }
                 ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetMetaclassParams"
-            },
-            "documentation": "Request to get the meta class of a type."
-        },
-        {
-            "method": "typeServer/getTypeOfDeclaration",
-            "typeName": "GetTypeOfDeclarationRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetTypeOfDeclarationParams"
-            },
-            "documentation": "Request to get the type of a declaration."
-        },
-        {
-            "method": "typeServer/getRepr",
-            "typeName": "GetReprRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetReprParams"
-            },
-            "documentation": "Request to get the string representation of a type in a human-readable format. This may or may not be the same as the type's \"name\"."
-        },
-        {
-            "method": "typeServer/getDocString",
-            "typeName": "GetDocStringRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetDocStringParams"
-            },
-            "documentation": "Request to get the docstring for a specific declaration."
-        },
-        {
-            "method": "typeServer/resolveImportDeclaration",
-            "typeName": "ResolveImportDeclarationRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "reference",
-                        "name": "Declaration"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "ResolveImportDeclarationParams"
-            },
-            "documentation": "Request to resolve an import declaration."
-        },
-        {
-            "method": "typeServer/resolveImport",
-            "typeName": "ResolveImportRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "ResolveImportParams"
-            },
-            "documentation": "Request to resolve an import. This is used to resolve the import name to its location in the file system."
-        },
-        {
-            "method": "typeServer/getTypeAliasInfo",
-            "typeName": "GetTypeAliasInfoRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "reference",
-                        "name": "TypeAliasInfo"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetTypeAliasInfoParams"
-            },
-            "documentation": "Get information about a type alias."
-        },
-        {
-            "method": "typeServer/combineTypes",
-            "typeName": "CombineTypesRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "CombineTypesParams"
-            },
-            "documentation": "Request to combine types. This is used to combine multiple types into a single type."
-        },
-        {
-            "method": "typeServer/createInstanceType",
-            "typeName": "CreateInstanceTypeRequest",
-            "result": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    {
-                        "kind": "base",
-                        "name": "null"
-                    }
-                ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "CreateInstanceTypeParams"
-            },
-            "documentation": "Request to generate an instance type representation for the provided type."
+            }
         },
         {
             "method": "typeServer/getPythonSearchPaths",
             "typeName": "GetPythonSearchPathsRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Request to get the search paths that the type server uses for Python modules.",
+            "params": {
+                "kind": "reference",
+                "name": "GetPythonSearchPathsParams"
+            },
             "result": {
                 "kind": "or",
                 "items": [
@@ -487,27 +188,50 @@
                         "name": "null"
                     }
                 ]
-            },
-            "messageDirection": "clientToServer",
-            "params": {
-                "kind": "reference",
-                "name": "GetPythonSearchPathsParams"
-            },
-            "documentation": "Request to get the search paths that the type server uses for Python modules."
+            }
         },
         {
-            "method": "typeServer/fetchTypeProperties",
-            "typeName": "FetchTypePropertiesRequest",
-            "result": {
-                "kind": "reference",
-                "name": "Type"
-            },
+            "method": "typeServer/getSnapshot",
+            "typeName": "GetSnapshotRequest",
             "messageDirection": "clientToServer",
+            "documentation": "Request from client to get the current snapshot of the type server. A snapshot is a point-in-time representation of the type server's state, including all loaded files and their types. A type server should change its snapshot whenever any type it might have returned is no longer valid. Meaning types are only usable for the snapshot they were returned with. Snapshots are not meant to survive any changes that would make the type server throw away its internal cache. They are merely an identifier to indicate to the client that the type server will accept requests for types from that snapshot.",
+            "result": {
+                "kind": "base",
+                "name": "number"
+            }
+        },
+        {
+            "method": "typeServer/getSupportedProtocolVersion",
+            "typeName": "GetSupportedProtocolVersionRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Request to get the version of the protocol the type server supports. Returns a string representation of the protocol version (should be semver format)",
+            "result": {
+                "kind": "base",
+                "name": "string"
+            }
+        },
+        {
+            "method": "typeServer/resolveImport",
+            "typeName": "ResolveImportRequest",
+            "messageDirection": "clientToServer",
+            "documentation": "Request to resolve an import. This is used to resolve the import name to its location in the file system.",
             "params": {
                 "kind": "reference",
-                "name": "FetchTypePropertiesParams"
+                "name": "ResolveImportParams"
             },
-            "documentation": "Request to fetch category properties for the given type."
+            "result": {
+                "kind": "or",
+                "items": [
+                    {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    {
+                        "kind": "base",
+                        "name": "null"
+                    }
+                ]
+            }
         }
     ],
     "notifications": [
@@ -515,157 +239,129 @@
             "method": "typeServer/snapshotChanged",
             "typeName": "SnapshotChangedNotification",
             "messageDirection": "serverToClient",
+            "documentation": "Notification sent by the server to indicate any outstanding snapshots are invalid.",
             "params": {
                 "kind": "reference",
-                "name": "SnapshotChangedParams"
-            },
-            "documentation": "Notification sent by the server to indicate any outstanding snapshots are invalid."
-        },
-        {
-            "method": "typeServer/diagnosticsChanged",
-            "typeName": "DiagnosticsChangedNotification",
-            "messageDirection": "serverToClient",
-            "params": {
-                "kind": "reference",
-                "name": "DiagnosticsChangedParams"
-            },
-            "documentation": "Notification sent by the server to indicate that diagnostics have changed and the client should re-request diagnostics for the file."
+                "name": "{ old: number; new: number }"
+            }
         }
     ],
-    "constants": [
-        {
-            "name": "TypeServerVersion",
-            "type": {
-                "kind": "base",
-                "name": "string"
+    "types": {
+        "TypeServerVersion": {
+            "kind": "stringEnum",
+            "values": {
+                "v0_1_0": "0.1.0",
+                "v0_2_0": "0.2.0",
+                "v0_3_0": "0.3.0",
+                "v0_4_0": "0.4.0",
+                "current": "0.4.1"
             },
-            "value": "0.4.1",
-            "documentation": "The version of the Type Server Protocol"
+            "valueDocumentation": {
+                "v0_1_0": "Initial protocol version",
+                "v0_2_0": "Added new request types and fields",
+                "v0_3_0": "Switch to more complex types",
+                "v0_4_0": "Switch to Type union and using stubs",
+                "current": "Add multi-connection negotiation and control requests"
+            }
         },
-        {
-            "name": "InvalidHandle",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "value": -1,
-            "documentation": "Represents an invalid handle value"
+        "ConnectionTransportKind": {
+            "kind": "stringEnum",
+            "values": {
+                "Ipc": "ipc"
+            }
         },
-        {
-            "name": "ReturnSymbolName",
-            "type": {
-                "kind": "base",
-                "name": "string"
-            },
-            "value": "__return__",
-            "documentation": "Special name for the return value of a function or method."
-        }
-    ],
-    "structures": [
-        {
-            "name": "Position",
-            "properties": [
-                {
-                    "name": "line",
-                    "type": {
-                        "kind": "base",
-                        "name": "uinteger"
-                    },
-                    "documentation": "Line position in a document (zero-based)."
-                },
-                {
-                    "name": "character",
-                    "type": {
-                        "kind": "base",
-                        "name": "uinteger"
-                    },
-                    "documentation": "Character offset on a line in a document (zero-based)."
-                }
+        "TypeFlags": {
+            "kind": "stringLiteral",
+            "value": [
+                "None",
+                "Instantiable",
+                "Instance",
+                "Callable",
+                "Literal",
+                "Interface",
+                "Generic",
+                "FromAlias",
+                "Unpacked",
+                "Optional",
+                "Unbound"
             ],
-            "documentation": "Position in a text document expressed as zero-based line and character offset."
+            "documentation": "Flags that describe the characteristics of a type. These flags can be combined using bitwise operations.",
+            "valueDocumentation": {
+                "Instantiable": "Indicates if the type can be instantiated.",
+                "Instance": "Indicates if the type represents an instance (as opposed to a class or type itself).",
+                "Callable": "Indicates if an instance of the type can be called like a function. (It has a `__call__` method).",
+                "Literal": "Indicates if the instance is a literal (like `42`, `\"hello\"`, etc.).",
+                "Interface": "Indicates if the type is an interface (a type that defines a set of methods and properties). In Python this would be a Protocol.",
+                "Generic": "Indicates if the type is a generic type (a type that can be parameterized with other types).",
+                "FromAlias": "Indicates if the type came from an alias (a type that refers to another type).",
+                "Unpacked": "Indicates if the type is unpacked (used with TypeVarTuple).",
+                "Optional": "Indicates if the type is optional (used with Tuple type arguments).",
+                "Unbound": "Indicates if the type is unbound (used with *args in tuple type arguments)."
+            }
         },
-        {
-            "name": "Range",
-            "properties": [
-                {
-                    "name": "start",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Position"
-                    },
-                    "documentation": "The range's start position."
-                },
-                {
-                    "name": "end",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Position"
-                    },
-                    "documentation": "The range's end position."
-                }
+        "DeclarationCategory": {
+            "kind": "stringLiteral",
+            "value": ["Intrinsic", "Variable", "Param", "TypeParam", "TypeAlias", "Function", "Class", "Import"],
+            "documentation": "Represents the category of a declaration in the type system. This is used to classify declarations such as variables, functions, classes, etc.",
+            "valueDocumentation": {
+                "Intrinsic": "An intrinsic refers to a symbol that has no actual declaration in the source code, such as built-in types or functions. One such example is a '__class__' declaration.",
+                "Variable": "A variable is a named storage location that can hold a value.",
+                "Param": "A parameter is a variable that is passed to a function or method.",
+                "TypeParam": "This is for PEP 695 type parameters.",
+                "TypeAlias": "This is for PEP 695 type aliases.",
+                "Function": "A function is any construct that begins with the `def` keyword and has a body, which can be called with arguments.",
+                "Class": "A class is any construct that begins with the `class` keyword and has a body, which can be instantiated.",
+                "Import": "An import declaration, which is a reference to another module."
+            }
+        },
+        "TypeKind": {
+            "kind": "stringLiteral",
+            "value": [
+                "BuiltIn",
+                "Declared",
+                "Function",
+                "Class",
+                "Union",
+                "Module",
+                "TypeVar",
+                "Overloaded",
+                "Synthesized",
+                "TypeReference"
             ],
-            "documentation": "A range in a text document expressed as (zero-based) start and end positions."
+            "valueDocumentation": {
+                "BuiltIn": "unknown, any, never, etc.",
+                "Declared": "Base for source-declared types (rarely used directly)",
+                "Function": "Functions and methods from def statements",
+                "Class": "Classes from class statements",
+                "Union": "int | str | None",
+                "Module": "import os -> os is ModuleType",
+                "TypeVar": "T, P, Ts in generics",
+                "Overloaded": "Functions with multiple @overload signatures",
+                "Synthesized": "Types that are synthesized by the type checker",
+                "TypeReference": "Reference by ID for deduplication"
+            }
         },
-        {
-            "name": "Diagnostic",
-            "properties": [
-                {
-                    "name": "range",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Range"
-                    },
-                    "documentation": "The range at which the message applies."
-                },
-                {
-                    "name": "severity",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "optional": true,
-                    "documentation": "The diagnostic's severity."
-                },
-                {
-                    "name": "code",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "base",
-                                "name": "integer"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "string"
-                            }
-                        ]
-                    },
-                    "optional": true,
-                    "documentation": "The diagnostic's code."
-                },
-                {
-                    "name": "source",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "optional": true,
-                    "documentation": "A human-readable string describing the source of this diagnostic."
-                },
-                {
-                    "name": "message",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The diagnostic's message."
-                }
-            ],
-            "documentation": "Represents a diagnostic, such as a compiler error or warning."
+        "DeclarationKind": {
+            "kind": "stringLiteral",
+            "value": ["Regular", "Synthesized"],
+            "valueDocumentation": {
+                "Regular": "Declaration exists in source code with AST node",
+                "Synthesized": "Declaration created by type checker (no source node)"
+            }
         },
-        {
-            "name": "Node",
+        "Variance": {
+            "kind": "stringLiteral",
+            "value": ["Auto", "Unknown", "Invariant", "Covariant", "Contravariant"],
+            "valueDocumentation": {
+                "Auto": "Variance not yet determined, will be inferred",
+                "Unknown": "Variance cannot be determined",
+                "Invariant": "No subtyping relationship (default for mutable types)",
+                "Covariant": "Preserves subtyping: Generic[Child] <: Generic[Parent]",
+                "Contravariant": "Reverses subtyping: Generic[Parent] <: Generic[Child]"
+            }
+        },
+        "Node": {
+            "kind": "interface",
             "properties": [
                 {
                     "name": "uri",
@@ -673,6 +369,7 @@
                         "kind": "base",
                         "name": "string"
                     },
+                    "optional": false,
                     "documentation": "URI of the source file containing this node."
                 },
                 {
@@ -681,20 +378,94 @@
                         "kind": "reference",
                         "name": "Range"
                     },
-                    "documentation": "The range of the node in the source file. This is a zero-based range, meaning the start and end positions are both zero-based. The range uses character offsets the same way the LSP does."
+                    "optional": false,
+                    "documentation": "The range of the node in the source file. This is a zero-based range, meaning the start and end positions are both zero-based The range uses character offsets the same way the LSP does."
                 }
             ],
-            "documentation": "Represents a node in an AST (Abstract Syntax Tree) or similar structure."
+            "documentation": "Represents a location in source code (a node in the AST). Used to point to specific declarations, expressions, or statements in Python source files. Used for: - Pointing to where a type is declared - Identifying the location of expressions for type inference - Error reporting and diagnostics - Linking types back to their source definitions Examples: - For `def foo():`, the node points to the function declaration - For a variable `x = 42`, the node points to the assignment - For default parameter values in functions"
         },
-        {
-            "name": "ModuleName",
+        "TypeServerMultiConnectionCapability": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "supportedTransports",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "ConnectionTransportKind"
+                        }
+                    },
+                    "optional": false
+                }
+            ],
+            "documentation": "Capability shape exchanged via the LSP initialize request/response under `capabilities.experimental.typeServerMultiConnection`."
+        },
+        "ConnectionRequestParams": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "type",
+                    "type": {
+                        "kind": "stringLiteral",
+                        "value": ["open", "close"]
+                    },
+                    "optional": false,
+                    "documentation": "Connection operation kind. Valid values are `open` and `close`."
+                },
+                {
+                    "name": "kind",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ConnectionTransportKind"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "args",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "string"
+                        }
+                    },
+                    "optional": true
+                }
+            ],
+            "documentation": "Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed."
+        },
+        "ConnectionRequestResult": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "success",
+                    "type": {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    "optional": false
+                },
+                {
+                    "name": "message",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": true
+                }
+            ]
+        },
+        "ModuleName": {
+            "kind": "interface",
             "properties": [
                 {
                     "name": "leadingDots",
                     "type": {
                         "kind": "base",
-                        "name": "integer"
+                        "name": "number"
                     },
+                    "optional": false,
                     "documentation": "The leading dots in the module name. This is used to determine the relative import level."
                 },
                 {
@@ -706,282 +477,14 @@
                             "name": "string"
                         }
                     },
+                    "optional": false,
                     "documentation": "The parts of the module name, split by dots. For example, for `my_module.sub_module`, this would be `['my_module', 'sub_module']`."
                 }
             ],
-            "documentation": "Represents a module name with optional leading dots for relative imports."
+            "documentation": "Represents a Python module name, handling both absolute and relative imports. Used for: - Import statement resolution - Tracking module dependencies - Resolving relative imports (from . import, from .. import) Examples: - `import os.path`: leadingDots=0, nameParts=['os', 'path'] - `from . import utils`: leadingDots=1, nameParts=['utils'] - `from ...parent import module`: leadingDots=3, nameParts=['parent', 'module'] - `import mymodule`: leadingDots=0, nameParts=['mymodule']"
         },
-        {
-            "name": "Type",
-            "properties": [
-                {
-                    "name": "handle",
-                    "type": {
-                        "kind": "reference",
-                        "name": "TypeHandle"
-                    },
-                    "documentation": "Unique identifier for the type definition within the snapshot. A handle doesn't need to exist beyond the lifetime of the snapshot."
-                },
-                {
-                    "name": "category",
-                    "type": {
-                        "kind": "reference",
-                        "name": "TypeCategory"
-                    },
-                    "documentation": "Essential classification of the Type."
-                },
-                {
-                    "name": "flags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "TypeFlags"
-                    },
-                    "documentation": "Flags describing the type."
-                },
-                {
-                    "name": "moduleName",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "reference",
-                                "name": "ModuleName"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "documentation": "Name of the module the type comes from"
-                },
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "Simple name of the type. For example, for a class `MyClass` in module `my_module`, this would be `MyClass`."
-                },
-                {
-                    "name": "aliasName",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "optional": true,
-                    "documentation": "The typing module defines aliases for builtin types (e.g. Tuple, List, Dict). This field holds the alias name."
-                },
-                {
-                    "name": "categoryFlags",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "Flags specific to the category. For example, for a class type, this would be ClassFlags. For a function type, this would be FunctionFlags."
-                },
-                {
-                    "name": "categoryProperties",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Properties"
-                    },
-                    "optional": true,
-                    "documentation": "Properties specific to the category, such as function parameters. Returned only if requested with `fetchPropertiesFlags`."
-                },
-                {
-                    "name": "decl",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "reference",
-                                "name": "Declaration"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "documentation": "Declaration of the type, if available."
-                }
-            ],
-            "documentation": "Represents a type in the type system."
-        },
-        {
-            "name": "Properties",
-            "properties": [
-                {
-                    "name": "fetchedPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertiesFlags"
-                    },
-                    "documentation": "Bit flags indicating which category-specific property blocks were fetched for this type."
-                }
-            ],
-            "documentation": "Base for category specific property containers. Includes bit flags indicating which properties are present."
-        },
-        {
-            "name": "AnyProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future 'Any' category properties."
-        },
-        {
-            "name": "FunctionProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future function-specific keys (e.g. parameter default summaries)."
-        },
-        {
-            "name": "OverloadedProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future overloaded-function specific keys."
-        },
-        {
-            "name": "ClassProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future class-specific keys."
-        },
-        {
-            "name": "ModuleProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future module-specific keys."
-        },
-        {
-            "name": "UnionProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future union-specific keys."
-        },
-        {
-            "name": "TypeVarProperties",
-            "properties": [],
-            "documentation": "Currently empty extension of Properties reserved for future type variable-specific keys."
-        },
-        {
-            "name": "Declaration",
-            "properties": [
-                {
-                    "name": "handle",
-                    "type": {
-                        "kind": "reference",
-                        "name": "DeclarationHandle"
-                    },
-                    "documentation": "Unique identifier for the declaration within the session."
-                },
-                {
-                    "name": "category",
-                    "type": {
-                        "kind": "reference",
-                        "name": "DeclarationCategory"
-                    },
-                    "documentation": "Category of this symbol (function, variable, etc.)."
-                },
-                {
-                    "name": "flags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "DeclarationFlags"
-                    },
-                    "documentation": "Extra information about the declaration."
-                },
-                {
-                    "name": "node",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Node"
-                    },
-                    "optional": true,
-                    "documentation": "Parse node associated with the declaration"
-                },
-                {
-                    "name": "moduleName",
-                    "type": {
-                        "kind": "reference",
-                        "name": "ModuleName"
-                    },
-                    "documentation": "The dot-separated import name for the file that contains the declaration."
-                },
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The symbol name for the declaration (as the user sees it)"
-                },
-                {
-                    "name": "uri",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The file that contains the declaration. Unless this is an import declaration, then the uri refers to the file the import is referring to."
-                }
-            ],
-            "documentation": "Represents a symbol declaration in the type system."
-        },
-        {
-            "name": "Symbol",
-            "properties": [
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The name of the symbol found."
-                },
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type of the symbol found."
-                },
-                {
-                    "name": "decls",
-                    "type": {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Declaration"
-                        }
-                    },
-                    "documentation": "The declarations for the symbol. This can include multiple declarations for the same symbol, such as when a symbol is defined in multiple files."
-                },
-                {
-                    "name": "flags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "SymbolFlags"
-                    },
-                    "documentation": "Flags giving more information about the symbol."
-                },
-                {
-                    "name": "parent",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "reference",
-                                "name": "Type"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "optional": true,
-                    "documentation": "The type that is the semantic parent of this symbol. For example if the symbol is for a parameter, the parent would be the function or method that contains the parameter. If the symbol is for a class member, the parent would be the class that contains the member."
-                }
-            ],
-            "documentation": "Symbol information for a node"
-        },
-        {
-            "name": "ResolveImportOptions",
+        "ResolveImportOptions": {
+            "kind": "interface",
             "properties": [
                 {
                     "name": "resolveLocalNames",
@@ -990,7 +493,7 @@
                         "name": "boolean"
                     },
                     "optional": true,
-                    "documentation": "Whether to resolve local names in the import declaration."
+                    "documentation": "Whether to resolve local names in the import declaration. When true, considers local variable assignments that shadow imports."
                 },
                 {
                     "name": "allowExternallyHiddenAccess",
@@ -999,7 +502,7 @@
                         "name": "boolean"
                     },
                     "optional": true,
-                    "documentation": "Whether to allow access to members that are hidden by external modules."
+                    "documentation": "Whether to allow access to members that are hidden by external modules. When true, permits access to symbols marked as private (e.g., _private or not in __all__)."
                 },
                 {
                     "name": "skipFileNeededCheck",
@@ -1008,13 +511,13 @@
                         "name": "boolean"
                     },
                     "optional": true,
-                    "documentation": "Whether to skip checking if the file is needed for the import resolution."
+                    "documentation": "Whether to skip checking if the file is needed for the import resolution. When true, optimizes by not verifying file existence/validity."
                 }
             ],
-            "documentation": "Options for resolving an import declaration."
+            "documentation": "Options for customizing import resolution behavior. Controls how the type server resolves import statements and accesses imported symbols. Used for: - Fine-tuning import resolution during type checking - Controlling access to private/hidden module members - Optimizing resolution by skipping file checks TODO: See if we can remove this as these are pretty specific to Pyright at the moment. Examples: ```python # resolveLocalNames affects whether local assignments are resolved: from module import name name = something_else  # Does 'name' refer to import or local assignment? # allowExternallyHiddenAccess affects access to _private names: from module import _internal_function  # Normally hidden from external access ```"
         },
-        {
-            "name": "ResolveImportParams",
+        "ResolveImportParams": {
+            "kind": "interface",
             "properties": [
                 {
                     "name": "sourceUri",
@@ -1022,7 +525,8 @@
                         "kind": "base",
                         "name": "string"
                     },
-                    "documentation": "The URI of the source file where the import is referenced."
+                    "optional": false,
+                    "documentation": "The URI of the source file where the import is referenced. Used to resolve relative imports and determine the import context."
                 },
                 {
                     "name": "moduleDescriptor",
@@ -1030,625 +534,23 @@
                         "kind": "reference",
                         "name": "ModuleName"
                     },
-                    "documentation": "The descriptor of the imported module."
+                    "optional": false,
+                    "documentation": "The descriptor of the imported module. Contains the module name parts and leading dots for relative imports."
                 },
                 {
                     "name": "snapshot",
                     "type": {
                         "kind": "base",
-                        "name": "integer"
+                        "name": "number"
                     },
-                    "documentation": "The snapshot version."
+                    "optional": false,
+                    "documentation": "Snapshot version of the type server. Type server should throw a ServerCanceled exception if this snapshot is no longer current."
                 }
             ],
-            "documentation": "Parameters for resolving an import"
+            "documentation": "Parameters for the ResolveImportRequest. Provides the context needed to resolve a Python import statement to its file location. Used when: - Resolving `import` or `from...import` statements - Finding the file that contains an imported module - Navigating to imported symbols Examples: ```python # In file.py: from os.path import join  # sourceUri = file.py, moduleDescriptor = os.path import mymodule          # sourceUri = file.py, moduleDescriptor = mymodule from . import utils      # sourceUri = file.py, moduleDescriptor = .utils (relative) ```"
         },
-        {
-            "name": "GetSymbolsForTypeParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type for which the symbols are being requested. If this is a class, the symbols are based on the members of the class. If this is a function, the symbols are the parameters and the return value."
-                },
-                {
-                    "name": "node",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "reference",
-                                "name": "Node"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "optional": true,
-                    "documentation": "The location where the symbols are being requested. This can help search for symbols."
-                },
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "optional": true,
-                    "documentation": "The name to search for. If undefined, returns all the symbols for the type or node."
-                },
-                {
-                    "name": "flags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "SymbolSearchFlags"
-                    },
-                    "documentation": "Flags used to do the search"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version of the type server state."
-                }
-            ],
-            "documentation": "Parameters for getting symbols for a type."
-        },
-        {
-            "name": "GetSymbolsForNodeParams",
-            "properties": [
-                {
-                    "name": "node",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Node"
-                    },
-                    "documentation": "The location to search for symbols from. This node is essentially used to scope the symbol search. It can be a Module node in order to search for top level symbols."
-                },
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "optional": true,
-                    "documentation": "The name to search for. If undefined, returns all the symbols for the type or node."
-                },
-                {
-                    "name": "flags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "SymbolSearchFlags"
-                    },
-                    "documentation": "Flags used to do the search"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version of the type server state."
-                }
-            ],
-            "documentation": "Parameters for getting symbols for a node."
-        },
-        {
-            "name": "GetBuiltinTypeParams",
-            "properties": [
-                {
-                    "name": "scopingNode",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Node"
-                    },
-                    "documentation": "The node that is used to scope the builtin type. Every module may have a different set of builtins based on where the module is located."
-                },
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The name of the builtin type being requested."
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version of the type server state."
-                }
-            ],
-            "documentation": "Parameters for getting builtin type information."
-        },
-        {
-            "name": "TypeAliasInfo",
-            "properties": [
-                {
-                    "name": "name",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The original name of the alias."
-                },
-                {
-                    "name": "typeArgs",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "array",
-                                "element": {
-                                    "kind": "reference",
-                                    "name": "Type"
-                                }
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "documentation": "The arguments for the type alias, if any."
-                }
-            ],
-            "documentation": "Information about a type alias."
-        },
-        {
-            "name": "GetDiagnosticsParams",
-            "properties": [
-                {
-                    "name": "uri",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The URI of the file to get diagnostics for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                }
-            ],
-            "documentation": "Parameters for getting diagnostics for a file."
-        },
-        {
-            "name": "GetDiagnosticsVersionParams",
-            "properties": [
-                {
-                    "name": "uri",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "documentation": "The URI of the file"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                }
-            ],
-            "documentation": "Parameters for getting diagnostics version for a file."
-        },
-        {
-            "name": "GetTypeParams",
-            "properties": [
-                {
-                    "name": "node",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Node"
-                    },
-                    "documentation": "The node to get type information for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Bit flags indicating which category properties to fetch for the returned type. If omitted, no properties are fetched initially."
-                }
-            ],
-            "documentation": "Parameters for getting type information for a node."
-        },
-        {
-            "name": "GetTypeArgsParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type to get arguments for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for returned type arguments."
-                }
-            ],
-            "documentation": "Parameters for getting type arguments."
-        },
-        {
-            "name": "GetOverloadsParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type to get overloads for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for each overload type."
-                }
-            ],
-            "documentation": "Parameters for getting function overloads."
-        },
-        {
-            "name": "GetMatchingOverloadsParams",
-            "properties": [
-                {
-                    "name": "callNode",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Node"
-                    },
-                    "documentation": "The call node to get matching overloads for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for each matching overload type."
-                }
-            ],
-            "documentation": "Parameters for getting matching overloads for a call."
-        },
-        {
-            "name": "GetMetaclassParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type to get metaclass for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for the metaclass type."
-                }
-            ],
-            "documentation": "Parameters for getting metaclass of a type."
-        },
-        {
-            "name": "GetTypeOfDeclarationParams",
-            "properties": [
-                {
-                    "name": "decl",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Declaration"
-                    },
-                    "documentation": "The declaration to get type for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for the resulting type."
-                }
-            ],
-            "documentation": "Parameters for getting type of a declaration."
-        },
-        {
-            "name": "GetReprParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type to get representation for"
-                },
-                {
-                    "name": "flags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "TypeReprFlags"
-                    },
-                    "documentation": "Formatting flags"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                }
-            ],
-            "documentation": "Parameters for getting type representation."
-        },
-        {
-            "name": "GetDocStringParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "reference",
-                                "name": "Type"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "optional": true,
-                    "documentation": "The type context"
-                },
-                {
-                    "name": "decl",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Declaration"
-                    },
-                    "documentation": "The declaration to get documentation for"
-                },
-                {
-                    "name": "boundObjectOrClass",
-                    "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "reference",
-                                "name": "Type"
-                            },
-                            {
-                                "kind": "base",
-                                "name": "null"
-                            }
-                        ]
-                    },
-                    "optional": true,
-                    "documentation": "The bound object or class type"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                }
-            ],
-            "documentation": "Parameters for getting documentation string."
-        },
-        {
-            "name": "ResolveImportDeclarationParams",
-            "properties": [
-                {
-                    "name": "decl",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Declaration"
-                    },
-                    "documentation": "The import declaration to resolve"
-                },
-                {
-                    "name": "options",
-                    "type": {
-                        "kind": "reference",
-                        "name": "ResolveImportOptions"
-                    },
-                    "documentation": "Resolution options"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                }
-            ],
-            "documentation": "Parameters for resolving import declaration."
-        },
-        {
-            "name": "GetTypeAliasInfoParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type to get alias info for"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for the alias target type."
-                }
-            ],
-            "documentation": "Parameters for getting type alias information."
-        },
-        {
-            "name": "CombineTypesParams",
-            "properties": [
-                {
-                    "name": "types",
-                    "type": {
-                        "kind": "array",
-                        "element": {
-                            "kind": "reference",
-                            "name": "Type"
-                        }
-                    },
-                    "documentation": "The types to combine"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for the combined type."
-                }
-            ],
-            "documentation": "Parameters for combining types."
-        },
-        {
-            "name": "CreateInstanceTypeParams",
-            "properties": [
-                {
-                    "name": "type",
-                    "type": {
-                        "kind": "reference",
-                        "name": "Type"
-                    },
-                    "documentation": "The type to create instance from"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "optional": true,
-                    "documentation": "Optional bit flags indicating which category properties to fetch for the created instance type."
-                }
-            ],
-            "documentation": "Parameters for creating instance type."
-        },
-        {
-            "name": "GetPythonSearchPathsParams",
+        "GetPythonSearchPathsParams": {
+            "kind": "interface",
             "properties": [
                 {
                     "name": "fromUri",
@@ -1656,73 +558,191 @@
                         "kind": "base",
                         "name": "string"
                     },
-                    "documentation": "The URI to get search paths from"
+                    "optional": false,
+                    "documentation": "Root folder to get search paths from. Determines the Python environment and project context for path resolution."
                 },
                 {
                     "name": "snapshot",
                     "type": {
                         "kind": "base",
-                        "name": "integer"
+                        "name": "number"
                     },
-                    "documentation": "The snapshot version"
+                    "optional": false,
+                    "documentation": "Snapshot version of the type server. Type server should throw a ServerCanceled exception if this snapshot is no longer current."
                 }
             ],
-            "documentation": "Parameters for getting Python search paths."
+            "documentation": "Parameters for the GetPythonSearchPathsRequest. Requests the list of directories that Python searches for modules and packages. The search paths include: - Standard library directories - Site-packages directories (third-party packages) - Virtual environment paths (if active) - Project-specific paths (PYTHONPATH, src directories) Used for: - Resolving import statements to find module files - Auto-import suggestions - Determining which packages are available Example search paths: ``` [ \"/usr/lib/python3.11\",              # Standard library \"/venv/lib/python3.11/site-packages\",  # Virtual env packages \"/project/src\"                       # Project source ] ```"
         },
-        {
-            "name": "FetchTypePropertiesParams",
+        "SpecializedFunctionTypes": {
+            "kind": "interface",
             "properties": [
                 {
-                    "name": "type",
+                    "name": "parameterTypes",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "Type"
+                        }
+                    },
+                    "optional": false,
+                    "documentation": "Specialized types for each of the parameters in the \"parameters\" array. Array matches the parameters array, with type variables replaced by concrete types. Example: For `def foo[T](x: T)` specialized to `T=int`, parameterTypes=[int]."
+                },
+                {
+                    "name": "parameterDefaultTypes",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "or",
+                            "items": [
+                                {
+                                    "kind": "reference",
+                                    "name": "Type"
+                                },
+                                {
+                                    "kind": "base",
+                                    "name": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "optional": true,
+                    "documentation": "Specialized types of default arguments for each parameter in the \"parameters\" array. If an entry is undefined or the entire array is missing, there is no specialized type, and the original \"defaultType\" should be used. Example: For a generic default value that depends on T, this contains the specialized version."
+                },
+                {
+                    "name": "returnType",
                     "type": {
                         "kind": "reference",
                         "name": "Type"
                     },
-                    "documentation": "The type whose category properties should be fetched"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "fetchPropertiesFlags",
-                    "type": {
-                        "kind": "reference",
-                        "name": "FetchPropertyFlags"
-                    },
-                    "documentation": "Bit flags indicating which category properties to fetch. Required."
+                    "optional": true,
+                    "documentation": "Specialized type of the declared return type. Undefined if there is no declared return type. Example: For `def foo[T](x: T) -> T` specialized to `T=int`, returnType=int."
                 }
             ],
-            "documentation": "Parameters for fetching category properties for a type."
+            "documentation": "Represents specialized (concrete) types for a generic function's parameters and return type. Used when generic type parameters are substituted with actual types. Fields: - parameterTypes: Concrete types for each parameter after type variable substitution - parameterDefaultTypes: Specialized types for default values (if different from declared) - returnType: Specialized return type after type variable substitution Examples: ```python # Generic function def identity[T](x: T) -> T: return x # When called as identity[int](42): # - parameterTypes = [int] (T substituted with int) # - returnType = int (T substituted with int) # For list.append bound to list[str]: # - parameterTypes = [str] (specialized from generic T) ```"
         },
-        {
-            "name": "SnapshotChangedParams",
+        "EnumLiteral": {
+            "kind": "interface",
             "properties": [
                 {
-                    "name": "old",
+                    "name": "className",
                     "type": {
                         "kind": "base",
-                        "name": "integer"
+                        "name": "string"
                     },
-                    "documentation": "The old snapshot version"
+                    "optional": false,
+                    "documentation": "Name of the enum class. Example: \"Color\" for the Color enum."
                 },
                 {
-                    "name": "new",
+                    "name": "itemName",
                     "type": {
                         "kind": "base",
-                        "name": "integer"
+                        "name": "string"
                     },
-                    "documentation": "The new snapshot version"
+                    "optional": false,
+                    "documentation": "Name of the specific enum member. Example: \"RED\" for Color.RED."
+                },
+                {
+                    "name": "itemType",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Type"
+                    },
+                    "optional": false,
+                    "documentation": "Type of the enum member's value. Example: int type if the enum values are integers."
                 }
             ],
-            "documentation": "Parameters for snapshot changed notification."
+            "documentation": "Represents a literal value from an Enum. Used to track specific enum members as literal types. Fields: - className: Name of the enum class - itemName: Name of the specific enum member - itemType: Type of the enum member's value Examples: ```python from enum import Enum class Color(Enum): RED = 1 GREEN = 2 BLUE = 3 # Color.RED is an EnumLiteral: # className=\"Color\", itemName=\"RED\", itemType=int (for value 1) def process(color: Literal[Color.RED]) -> None: pass  # EnumLiteral tracks that it's specifically Color.RED ```"
         },
-        {
-            "name": "DiagnosticsChangedParams",
+        "SentinelLiteral": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "classNode",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Node"
+                    },
+                    "optional": false,
+                    "documentation": "AST node pointing to the sentinel class definition. Used to locate the class in source code."
+                },
+                {
+                    "name": "moduleName",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "Fully qualified module name where the sentinel is defined. Example: \"dataclasses\" for dataclasses.MISSING."
+                },
+                {
+                    "name": "className",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "Name of the sentinel class. Example: \"_MISSING_TYPE\" for the class of dataclasses.MISSING."
+                }
+            ],
+            "documentation": "Represents a sentinel value (a unique object used as a marker). Used for special singleton values that act as sentinels in APIs. Fields: - classNode: AST node where the sentinel class is defined - moduleName: Module containing the sentinel - className: Name of the sentinel class Examples: ```python # Common sentinel pattern class _Sentinel: pass MISSING = _Sentinel() def get_value(key: str, default: int | _Sentinel = MISSING) -> int: ... # MISSING is a SentinelLiteral pointing to the _Sentinel class instance # Used in standard library (e.g., dataclasses.MISSING) from dataclasses import field, MISSING # MISSING is tracked as a SentinelLiteral ```"
+        },
+        "DeclarationBase": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "kind",
+                    "type": {
+                        "kind": "reference",
+                        "name": "T"
+                    },
+                    "optional": false,
+                    "documentation": "Discriminator field that determines which declaration variant this is. Regular: Has source code and AST node Synthesized: Created by type checker, no source node"
+                }
+            ],
+            "documentation": "Base interface for all declaration types. Provides the discriminator field for the Declaration union. This is a generic interface that is extended by: - RegularDeclaration (kind = Regular) - SynthesizedDeclaration (kind = Synthesized) The type parameter T ensures that the kind field matches the implementing interface. Used for type-safe discrimination: ```typescript if (declaration.kind === DeclarationKind.Regular) { // TypeScript knows this is RegularDeclaration const node = declaration.node; } ```"
+        },
+        "RegularDeclaration": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "category",
+                    "type": {
+                        "kind": "reference",
+                        "name": "DeclarationCategory"
+                    },
+                    "optional": false,
+                    "documentation": "Category of the declaration (Variable, Function, Class, etc.). Determines how the declaration should be interpreted. Example: DeclarationCategory.Function for `def foo():`."
+                },
+                {
+                    "name": "node",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Node"
+                    },
+                    "optional": false,
+                    "documentation": "AST node pointing to the declaration location in source code. Contains file URI and range information. Example: Points to the `def` keyword and function name for function declarations."
+                },
+                {
+                    "name": "name",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": true,
+                    "documentation": "Name of the declared symbol, or undefined for anonymous declarations. Example: \"foo\" for `def foo():`, undefined for lambda functions."
+                }
+            ],
+            "documentation": "Represents a declaration that exists in source code. Points to the actual AST node where a symbol is declared. Fields: - category: Type of declaration (Variable, Function, Class, etc.) - node: AST node pointing to the declaration location - name: Name of the declared symbol (undefined for anonymous/implicit declarations) Examples: ```python def my_function(x: int) -> str:  # Function declaration return str(x) class MyClass:  # Class declaration x: int      # Variable declaration T = TypeVar('T')  # TypeParam declaration ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "DeclarationBase"
+                }
+            ]
+        },
+        "SynthesizedDeclaration": {
+            "kind": "interface",
             "properties": [
                 {
                     "name": "uri",
@@ -1730,594 +750,592 @@
                         "kind": "base",
                         "name": "string"
                     },
-                    "documentation": "The URI of the file with changed diagnostics"
-                },
-                {
-                    "name": "snapshot",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The snapshot version"
-                },
-                {
-                    "name": "version",
-                    "type": {
-                        "kind": "base",
-                        "name": "integer"
-                    },
-                    "documentation": "The diagnostics version"
+                    "optional": false,
+                    "documentation": "URI of the file where this symbol is conceptually declared. For built-ins, this might be a special URI; for decorator-generated code, it's the file containing the decorator. Example: File URI of a @dataclass-decorated class for synthesized __init__."
                 }
             ],
-            "documentation": "Parameters for diagnostics changed notification."
+            "documentation": "Represents a synthesized declaration (not in source code). Used for implicitly created symbols like built-in types or decorator-generated members. Fields: - uri: The file URI where this is conceptually declared (often the module using it) Examples: ```python # Built-in functions have synthesized declarations len([1, 2, 3])  # len is synthesized, not from source # @dataclass generates __init__, __eq__, etc. - synthesized declarations @dataclass class Point: x: int y: int # Point.__init__ is synthesized ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "DeclarationBase"
+                }
+            ]
         },
-        {
-            "name": "ConnectionRequestParams",
+        "TypeAliasInfo": {
+            "kind": "interface",
             "properties": [
                 {
-                    "name": "type",
+                    "name": "name",
                     "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "stringLiteral",
-                                "value": "open"
-                            },
-                            {
-                                "kind": "stringLiteral",
-                                "value": "close"
-                            }
-                        ]
+                        "kind": "base",
+                        "name": "string"
                     },
-                    "documentation": "Connection operation kind. Valid values are `open` and `close`."
+                    "optional": false,
+                    "documentation": "Short name of the type alias. Example: \"IntList\" for `type IntList = list[int]`."
+                },
+                {
+                    "name": "fullName",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "Fully qualified name including module path. Example: \"mymodule.IntList\"."
+                },
+                {
+                    "name": "moduleName",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "Module where the type alias is defined. Example: \"mymodule\" for a type defined in mymodule.py."
+                },
+                {
+                    "name": "fileUri",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "URI of the file containing the type alias definition. Example: \"file:///path/to/mymodule.py\"."
+                },
+                {
+                    "name": "scopeId",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "Scope identifier for type variables used in this alias. Ensures type variables are scoped to this alias definition. Example: Different aliases can use the same type variable name 'T' without conflict."
+                },
+                {
+                    "name": "isTypeAliasType",
+                    "type": {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    "optional": false,
+                    "documentation": "True if this alias uses the `type` keyword (PEP 695), false for traditional assignment. Example: true for `type X = int`, false for `X = int`."
+                },
+                {
+                    "name": "typeParams",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "Type"
+                        }
+                    },
+                    "optional": true,
+                    "documentation": "Generic type parameters declared by this alias. Example: [T] for `type Pair[T] = tuple[T, T]`."
+                },
+                {
+                    "name": "typeArgs",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "Type"
+                        }
+                    },
+                    "optional": true,
+                    "documentation": "Concrete type arguments when this alias is specialized. Example: [int] when `Pair[int]` is used (specializing Pair[T])."
+                },
+                {
+                    "name": "computedVariance",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "Variance"
+                        }
+                    },
+                    "optional": true,
+                    "documentation": "Computed variance for each type parameter. Inferred based on how type parameters are used in the alias definition. Example: [Covariant] if the type parameter only appears in return positions."
+                }
+            ],
+            "documentation": "Contains metadata about a type alias. Used when a type is created through a type alias statement (PEP 613) or traditional assignment. Fields: - name: Short name of the alias - fullName: Fully qualified name including module path - moduleName: Module where the alias is defined - fileUri: File location of the alias definition - scopeId: Scope identifier for the alias (for scoped type variables) - isTypeAliasType: True if this uses the `type` keyword (PEP 695) - typeParams: Generic type parameters declared by the alias - typeArgs: Concrete type arguments when the alias is specialized - computedVariance: Inferred variance for type parameters Examples: ```python # PEP 695 style (isTypeAliasType=true) type IntList = list[int] # Traditional style (isTypeAliasType=false) IntList = list[int] # Generic alias with type parameters type Pair[T] = tuple[T, T] # typeParams=[T], can be specialized to Pair[int] # Using typing.TypeAlias from typing import TypeAlias UserId: TypeAlias = int ```"
+        },
+        "TypeBase": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "id",
+                    "type": {
+                        "kind": "base",
+                        "name": "number"
+                    },
+                    "optional": false,
+                    "documentation": "Unique identifier for this type instance. Used to detect cycles and cache type lookups. Example: During recursive type resolution, the id is checked to avoid infinite loops."
                 },
                 {
                     "name": "kind",
                     "type": {
                         "kind": "reference",
-                        "name": "ConnectionTransportKind"
-                    }
+                        "name": "T"
+                    },
+                    "optional": false,
+                    "documentation": "Discriminator field that determines which Type variant this is. Used for type narrowing when processing Type unions. Example: `if (type.kind === TypeKind.BuiltIn) { ... }`"
                 },
                 {
-                    "name": "args",
+                    "name": "flags",
+                    "type": {
+                        "kind": "reference",
+                        "name": "TypeFlags"
+                    },
+                    "optional": false,
+                    "documentation": "Bitfield of TypeFlags that describe characteristics of the type. Common flags: Instantiable (can create instances), Instance (is an instance), Callable (has __call__), Literal (is a literal value), Generic (has type parameters). Example: Check if type is callable: `(flags & TypeFlags.Callable) !== 0`"
+                },
+                {
+                    "name": "typeAliasInfo",
+                    "type": {
+                        "kind": "reference",
+                        "name": "TypeAliasInfo"
+                    },
+                    "optional": true,
+                    "documentation": "Information about type aliases. Present when this type was created from a type alias. Contains the alias name, module, file location, type parameters, and type arguments. Example: `type MyList = list[int]` - typeAliasInfo contains name=\"MyList\", typeArgs=[int]"
+                }
+            ],
+            "documentation": "Base interface for all Type variants. Provides common fields shared by all type representations in the protocol. This is the foundation interface extended by all Type types: - BuiltInType - RegularType (and its subclasses FunctionType, ClassType) - UnionType - ModuleType - TypeVarType - OverloadedType - SynthesizedType - TypeReference The type parameter T constrains the `kind` field to match the implementing type. Common fields: - id: Unique identifier for cycle detection and caching - kind: Discriminator for the Type union - flags: Characteristics of the type (Instantiable, Instance, Callable, etc.) - typeAliasInfo: Optional alias information if type comes from a type alias Used throughout the protocol to represent Python types in a serializable format."
+        },
+        "BuiltInType": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "declaration",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Declaration"
+                    },
+                    "optional": true,
+                    "documentation": "Optional declaration information for built-in types (usually undefined for true built-ins). Example: Some built-ins like __class__ have synthesized declarations."
+                },
+                {
+                    "name": "name",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "The name of the built-in type. Limited to specific known built-in types. 'unknown': Type cannot be determined 'any': Accepts any value (gradual typing) 'unbound': Variable not yet bound to a value 'ellipsis': The ... literal 'never': Type that never occurs (e.g., function that always raises) 'noreturn': Function that doesn't return (alias for never)"
+                },
+                {
+                    "name": "possibleType",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Type"
+                    },
+                    "optional": true,
+                    "documentation": "For 'unknown' types, this may contain a possible type based on context. Used when type inference has partial information but can't fully determine the type. Example: In `if isinstance(x, int): ...` the possibleType of unknown x might be int"
+                }
+            ],
+            "documentation": "Represents special built-in types that are fundamental to Python's type system. These are not regular classes but represent special semantic meanings. Used for: - Type inference failures (unknown) - Gradual typing (any) - Uninitialized variables (unbound) - Special literals (ellipsis for ...) - Non-returning functions (never/noreturn) Examples: - `unknown`: `x` in `def foo(x):` with no type hints and no usage to infer from - `any`: Explicit `Any` annotation or from untyped imports - `unbound`: Variable declared but not yet assigned: `x: int` (before assignment) - `ellipsis`: The `...` in `def foo(...): ...` or `Tuple[int, ...]` - `never`: `def raise_error() -> Never:` or function with only raise statements",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
+        },
+        "DeclaredType": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "declaration",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Declaration"
+                    },
+                    "optional": false,
+                    "documentation": "Declaration node information (source location, category, name). Points to where this type was declared in the source code. Example: For a function, this contains the node pointing to the 'def' keyword and function name."
+                }
+            ],
+            "documentation": "Base type for symbols that have a declaration in source code. This is the common parent for FunctionType and ClassType when the type comes from an actual declaration node in the parse tree. The type parameter T allows subtypes to specify their own TypeKind (e.g., Function or Class) while sharing the common declaration field. Used for: - Functions and methods with actual `def` statements (TypeKind.Function) - Classes with actual `class` statements (TypeKind.Class) - Variables with declarations in source (TypeKind.Declared) Not used for: - Synthesized types (use SynthesizedType) - Built-in types (use BuiltInType) Example: ```python def my_function(x: int) -> str:  # FunctionType with TypeKind.Function return str(x) class MyClass:  # ClassType with TypeKind.Class pass ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
+        },
+        "FunctionType": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "returnType",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Type"
+                    },
+                    "optional": true,
+                    "documentation": "The return type annotation of the function. Example: In `def foo() -> int:`, returnType is the int type."
+                },
+                {
+                    "name": "specializedTypes",
+                    "type": {
+                        "kind": "reference",
+                        "name": "SpecializedFunctionTypes"
+                    },
+                    "optional": true,
+                    "documentation": "Specialized versions of parameter types and return type when the function has type parameters. Contains concrete types substituted for generic type variables. Example: When calling `list[int].append(1)`, the self parameter is specialized to list[int]."
+                },
+                {
+                    "name": "boundToType",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Type"
+                    },
+                    "optional": true,
+                    "documentation": "The class or object instance that this method is bound to. Example: In `obj.method`, boundToType is the type of `obj`."
+                }
+            ],
+            "documentation": "Represents a function or method that has a declaration in the source code. Used for functions parsed from actual `def` statements. Uses TypeKind.Function for discrimination from ClassType and other types. Binding behavior: - boundToType: Contains the class/instance the method is bound to. Used for: - User-defined functions with `def` statements - Methods declared in source classes - Lambda functions (though simple ones) Not used for: - Built-in functions like `len`, `print` (use SynthesizedType) - Synthesized methods from decorators like @dataclass (use SynthesizedType) Example: ```python def calculate(x: int, y: int) -> int: return x + y class MyClass: def method(self, value: str) -> None: pass ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "DeclaredType"
+                }
+            ]
+        },
+        "ClassType": {
+            "kind": "interface",
+            "properties": [
+                {
+                    "name": "literalValue",
+                    "type": {
+                        "kind": "reference",
+                        "name": "LiteralValue"
+                    },
+                    "optional": true,
+                    "documentation": "The literal value if this class represents a literal (e.g., int literal 42, str literal \"hello\"). Can be a primitive value, enum member, or sentinel object. Example: For the literal `42`, literalValue = 42."
+                },
+                {
+                    "name": "typeArgs",
                     "type": {
                         "kind": "array",
                         "element": {
-                            "kind": "base",
-                            "name": "string"
+                            "kind": "reference",
+                            "name": "Type"
                         }
                     },
                     "optional": true,
-                    "documentation": "Transport-specific endpoint arguments. For `ipc`, provide either one full-duplex endpoint or two one-way endpoints. When two endpoints are provided, the first is the server input stream and the second is the server output stream."
+                    "documentation": "Type arguments when this class is a specialized generic type. Example: For `list[int]`, typeArgs = [int]."
                 }
             ],
-            "documentation": "Main-connection-only control request used to open or close extra read-only TSP channels after LSP initialization has completed."
-        },
-        {
-            "name": "ConnectionRequestResult",
-            "properties": [
+            "documentation": "Represents a class or class instance that has a declaration in the source code. Used for classes parsed from actual `class` statements. Uses TypeKind.Class for discrimination from FunctionType and other types. Used for: - User-defined classes with `class` statements - Class instances (instances of user-defined classes) - Specialized generic classes (e.g., `MyClass[int]`) - Literal instances (e.g., the number `42` is an instance of `int`) Not used for: - Built-in classes like `int`, `str`, `list` (use SynthesizedType) - Classes synthesized by decorators (use SynthesizedType) Example: ```python class Point: x: int y: int class Container[T]: value: T # point has ClassType (instance of Point) point = Point() # container has ClassType with typeArgs=[int] container: Container[int] = Container() ```",
+            "extends": [
                 {
-                    "name": "success",
-                    "type": {
-                        "kind": "base",
-                        "name": "boolean"
-                    }
-                },
-                {
-                    "name": "message",
-                    "type": {
-                        "kind": "base",
-                        "name": "string"
-                    },
-                    "optional": true
+                    "kind": "reference",
+                    "name": "DeclaredType"
                 }
             ]
-        }
-    ],
-    "enumerations": [
-        {
-            "name": "ConnectionTransportKind",
-            "type": {
-                "kind": "base",
-                "name": "string"
-            },
-            "values": [
-                {
-                    "name": "Ipc",
-                    "value": "ipc"
-                }
-            ],
-            "documentation": "Built-in transport kinds supported by the multi-connection protocol. The main connection uses stdio. Extra dynamically-opened connections are negotiated separately and are currently limited to local IPC."
         },
-        {
-            "name": "FetchPropertiesFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "UnionType": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "None",
-                    "value": 0
-                },
-                {
-                    "name": "All",
-                    "value": 4294967295,
-                    "documentation": "All fetchable properties. (0xFFFFFFFF)"
+                    "name": "subTypes",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "Type"
+                        }
+                    },
+                    "optional": false,
+                    "documentation": "Array of types that make up this union. Example: For `int | str | None`, subTypes = [int, str, None]."
                 }
             ],
-            "documentation": "Flags controlling which category properties are fetched for a type."
+            "documentation": "Represents a union of multiple types (Type1 | Type2 | ...). Used when a value can be one of several different types. Used for: - Explicit union type annotations using `|` or `Union[...]` - Optional types (which are unions with None) - Type narrowing results (e.g., after isinstance checks) - Inferred types from multiple branches Examples: ```python # Explicit union annotation def process(value: int | str) -> None: pass # Optional (union with None) def find(key: str) -> str | None: return None # Inferred union from branches if condition: x = 42        # int else: x = \"hello\"  # str # x has type int | str ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
         },
-        {
-            "name": "TypeCategory",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "ModuleType": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "Any",
-                    "value": 0,
-                    "documentation": "Type can be anything"
+                    "name": "moduleName",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "Fully qualified name of the module. Example: \"os.path\" for the os.path module."
                 },
                 {
-                    "name": "Function",
-                    "value": 1,
-                    "documentation": "Callable type"
-                },
-                {
-                    "name": "Overloaded",
-                    "value": 2,
-                    "documentation": "Functions defined with @overload decorator"
-                },
-                {
-                    "name": "Class",
-                    "value": 3,
-                    "documentation": "Class definition"
-                },
-                {
-                    "name": "Module",
-                    "value": 4,
-                    "documentation": "Module instance"
-                },
-                {
-                    "name": "Union",
-                    "value": 5,
-                    "documentation": "Union of two or more other types"
-                },
-                {
-                    "name": "TypeVar",
-                    "value": 6,
-                    "documentation": "Type variable"
+                    "name": "uri",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false,
+                    "documentation": "URI of the module's source file. Example: \"file:///path/to/module.py\" or \"<builtin>\" for built-in modules."
                 }
             ],
-            "documentation": "Represents a category of a type, such as class, function, variable, etc."
+            "documentation": "Represents a Python module as a type. Used when a module object itself is referenced (not its contents). Used for: - Module imports: `import os` makes `os` a ModuleType - Module attributes accessed via __file__, __name__, etc. - Submodule references: `os.path` is also a ModuleType The loaderFields contain all the symbols exported by the module that would be accessible via attribute access (module.symbol_name). Examples: ```python import os import os.path as path from typing import Protocol # `os` has ModuleType with loaderFields containing {\"path\": ..., \"getcwd\": ..., etc.} # `path` has ModuleType for the os.path module # In type stubs, Protocol is a module symbol that gets loaded ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
         },
-        {
-            "name": "TypeFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "OverloadedType": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "None",
-                    "value": 0
+                    "name": "overloads",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "reference",
+                            "name": "Type"
+                        }
+                    },
+                    "optional": false,
+                    "documentation": "List of overload signatures for this overloaded function. Each overload represents a different way the function can be called. Example: For a function with @overload decorators, each overload is in this array."
                 },
                 {
-                    "name": "Instantiable",
-                    "value": 1,
-                    "documentation": "Indicates if the type can be instantiated."
-                },
-                {
-                    "name": "Instance",
-                    "value": 2,
-                    "documentation": "Indicates if the type represents an instance (as opposed to a class or type itself)."
-                },
-                {
-                    "name": "Callable",
-                    "value": 4,
-                    "documentation": "Indicates if an instance of the type can be called like a function."
-                },
-                {
-                    "name": "Literal",
-                    "value": 8,
-                    "documentation": "Indicates if the instance is a literal (like `42`, `\"hello\"`, etc.)."
-                },
-                {
-                    "name": "Interface",
-                    "value": 16,
-                    "documentation": "Indicates if the type is an interface (a type that defines a set of methods and properties)."
-                },
-                {
-                    "name": "Generic",
-                    "value": 32,
-                    "documentation": "Indicates if the type is a generic type (a type that can be parameterized with other types)."
-                },
-                {
-                    "name": "FromAlias",
-                    "value": 64,
-                    "documentation": "Indicates if the type came from an alias (a type that refers to another type)."
-                },
-                {
-                    "name": "Unpacked",
-                    "value": 128,
-                    "documentation": "Indicates if the type is unpacked (used with TypeVarTuple)."
+                    "name": "implementation",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Type"
+                    },
+                    "optional": true,
+                    "documentation": "The implementation signature (if present). This is the actual function body, as opposed to the @overload declarations. Example: The non-decorated function definition after all @overload decorators."
                 }
             ],
-            "documentation": "Flags that describe the characteristics of a type. These flags can be combined using bitwise operations."
+            "documentation": "Represents an overloaded function with multiple signatures. Used when a function has multiple `@overload` decorators defining different call signatures. Used for: - Functions with @overload decorators - Built-in functions with multiple signatures (e.g., `range(stop)` vs `range(start, stop, step)`) - Methods with different signatures for different argument types The `overloads` array contains all the @overload signatures, and `implementation` contains the actual implementation (if present). Examples: ```python from typing import overload @overload def process(value: int) -> str: ... @overload def process(value: str) -> int: ... def process(value: int | str) -> int | str: if isinstance(value, int): return str(value) return len(value) # The type of `process` is OverloadedType with: # - overloads = [signature for (int)->str, signature for (str)->int] # - implementation = signature for (int|str)->(int|str) ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
         },
-        {
-            "name": "FunctionFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "SynthesizedTypeMetadata": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "None",
-                    "value": 0
+                    "name": "module",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ModuleType"
+                    },
+                    "optional": false
                 },
                 {
-                    "name": "Async",
-                    "value": 1,
-                    "documentation": "Indicates if the function is asynchronous."
-                },
-                {
-                    "name": "Generator",
-                    "value": 2,
-                    "documentation": "Indicates if the function is a generator (can yield values)."
-                },
-                {
-                    "name": "Abstract",
-                    "value": 4,
-                    "documentation": "Indicates if the function is abstract (must be implemented in a subclass)."
-                },
-                {
-                    "name": "Static",
-                    "value": 8,
-                    "documentation": "Indicates if the function has a @staticmethod decorator."
-                },
-                {
-                    "name": "GradualCallableForm",
-                    "value": 16,
-                    "documentation": "The *args and **kwargs parameters do not need to be present for this function to be compatible. This is used for Callable[..., x] and ... type arguments to ParamSpec and Concatenate."
+                    "name": "primaryDefinitionOffset",
+                    "type": {
+                        "kind": "base",
+                        "name": "number"
+                    },
+                    "optional": false
                 }
             ],
-            "documentation": "Flags that describe the characteristics of a function or method. These flags can be combined using bitwise operations."
+            "documentation": "Metadata about a synthesized type that provides additional context. This information is used by the client to enhance IntelliSense and type checking."
         },
-        {
-            "name": "ClassFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "SynthesizedType": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "None",
-                    "value": 0
+                    "name": "stubContent",
+                    "type": {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    "optional": false
                 },
                 {
-                    "name": "Enum",
-                    "value": 1,
-                    "documentation": "Indicates if the class is an enum (a special kind of class that defines a set of named values)."
-                },
-                {
-                    "name": "TypedDict",
-                    "value": 2,
-                    "documentation": "Indicates if the class is a TypedDict or derived from a TypedDict."
+                    "name": "metadata",
+                    "type": {
+                        "kind": "reference",
+                        "name": "SynthesizedTypeMetadata"
+                    },
+                    "optional": false
                 }
             ],
-            "documentation": "Flags that describe the characteristics of a class. These flags can be combined using bitwise operations."
+            "documentation": "Represents synthesized/generated types. When the type server generates its own types that do not directly correspond to source code declarations, it uses this handle. The stub content should be a complete, valid Python stub (.pyi) that includes: 1. All necessary imports (typing module, collections.abc, etc.) 2. TypeVar and ParamSpec declarations used in the type 3. Type aliases or class definitions 4. Function signatures with full parameter and return type annotations This approach is particularly useful for: - Synthesized methods from decorators like @dataclass.__init__ - NewType declarations - Generic type specializations Examples: # Example 1: Synthesized dataclass __init__ from dataclasses import dataclass @dataclass class Point: x: int y: int # Stub content for Point.__init__: \"\"\" def __init__(self, x: int, y: int) -> None: '''Initialize Point''' \"\"\" # metadata: { primaryDefinitionOffset: 0 } # Example 2: Generic function with TypeVar from typing import TypeVar T = TypeVar('T') def identity(x: T) -> T: return x # Stub content: \"\"\" from typing import TypeVar T = TypeVar('T') def identity(x: T) -> T: ... \"\"\" # metadata: { primaryDefinitionOffset: 45 } (offset points to 'def') # Example 3: ParamSpec function from typing import ParamSpec, Callable P = ParamSpec('P') def wrapper(func: Callable[P, int]) -> Callable[P, str]: ... # Stub content: \"\"\" from typing import ParamSpec, Callable P = ParamSpec('P') def wrapper(func: Callable[P, int]) -> Callable[P, str]: ... \"\"\" # metadata: { primaryDefinitionOffset: 67 } # Example 4: NewType from typing import NewType UserId = NewType('UserId', int) # Stub content: \"\"\" from typing import NewType UserId = NewType('UserId', int) \"\"\" # metadata: { primaryDefinitionOffset: 25 } (offset points to 'UserId') # Example 5: Complex generic specialization with ParamSpec class Wrapper[P, R]: func: Callable[P, R] def example(x: int, y: str) -> bool: ... w: Wrapper[(x: int, y: str), bool] = Wrapper() # Stub content for Wrapper[(x: int, y: str), bool]: \"\"\" from typing import ParamSpec, TypeVar, Generic, Callable P = ParamSpec('P') R = TypeVar('R') class Wrapper(Generic[P, R]): func: Callable[P, R] \"\"\" # metadata: { primaryDefinitionOffset: 87 } (offset points to 'class Wrapper') ``` Important: The stub content is used to reconstruct the type on the client side by: 1. Parsing the stub as a Python type stub file 2. Evaluating the type expressions within the stub 3. Extracting the resulting type for use in type checking and IntelliSense",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
         },
-        {
-            "name": "TypeVarFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "TypeReferenceType": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "None",
-                    "value": 0
-                },
-                {
-                    "name": "IsParamSpec",
-                    "value": 1,
-                    "documentation": "Indicates if the type variable is a ParamSpec (as defined in PEP 612)."
-                },
-                {
-                    "name": "IsTypeVarTuple",
-                    "value": 2,
-                    "documentation": "Indicates if the type variable is a TypeVarTuple (as defined in PEP 646)."
+                    "name": "typeReferenceId",
+                    "type": {
+                        "kind": "base",
+                        "name": "number"
+                    },
+                    "optional": false,
+                    "documentation": "Identifier that references another Type by its id. Used to avoid duplicating large type structures and handle forward references. Example: When a type appears multiple times, later occurrences use TypeReference pointing to the first occurrence's id."
                 }
             ],
-            "documentation": "Flags that describe the characteristics of a type variable. These flags can be combined using bitwise operations."
+            "documentation": "Represents a reference to another type by its ID. Used to avoid duplicating large type structures and to handle forward references. Used for: - Deduplication: When the same type appears multiple times, subsequent occurrences can reference the first occurrence instead of duplicating all fields - Cyclic references: Breaking cycles in recursive type definitions - Large types: Reducing payload size for complex types used repeatedly This is an optimization mechanism in the protocol to keep type handles compact when transmitting over the wire. Examples: ```python # Recursive type definition class Node: value: int next: Node | None  # 'Node' references back to itself # When serializing the type of 'next', the second occurrence of Node # uses TypeReferenceType pointing to the first Node's ID # Repeated complex type def process_lists( list1: list[dict[str, int]], list2: list[dict[str, int]],  # Can reference the type from list1 list3: list[dict[str, int]]   # Can reference the type from list1 ) -> None: pass ```",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "TypeBase"
+                }
+            ]
         },
-        {
-            "name": "DeclarationCategory",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "Range": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "Intrinsic",
-                    "value": 0,
-                    "documentation": "An intrinsic refers to a symbol that has no actual declaration in the source code, such as built-in types or functions."
+                    "name": "start",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Position"
+                    },
+                    "optional": false,
+                    "documentation": "The range's start position."
                 },
                 {
-                    "name": "Variable",
-                    "value": 1,
-                    "documentation": "A variable is a named storage location that can hold a value."
-                },
-                {
-                    "name": "Param",
-                    "value": 2,
-                    "documentation": "A parameter is a variable that is passed to a function or method."
-                },
-                {
-                    "name": "TypeParam",
-                    "value": 3,
-                    "documentation": "This is for PEP 695 type parameters."
-                },
-                {
-                    "name": "TypeAlias",
-                    "value": 4,
-                    "documentation": "This is for PEP 695 type aliases."
-                },
-                {
-                    "name": "Function",
-                    "value": 5,
-                    "documentation": "A function is any construct that begins with the `def` keyword and has a body, which can be called with arguments."
-                },
-                {
-                    "name": "Class",
-                    "value": 6,
-                    "documentation": "A class is any construct that begins with the `class` keyword and has a body, which can be instantiated."
-                },
-                {
-                    "name": "Import",
-                    "value": 7,
-                    "documentation": "An import declaration, which is a reference to another module."
+                    "name": "end",
+                    "type": {
+                        "kind": "reference",
+                        "name": "Position"
+                    },
+                    "optional": false,
+                    "documentation": "The range's end position."
                 }
             ],
-            "documentation": "Represents the category of a declaration in the type system."
+            "documentation": "A range in a text document expressed as (zero-based) start and end positions."
         },
-        {
-            "name": "DeclarationFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
+        "Position": {
+            "kind": "interface",
+            "properties": [
                 {
-                    "name": "None",
-                    "value": 0
+                    "name": "line",
+                    "type": {
+                        "kind": "base",
+                        "name": "uinteger"
+                    },
+                    "optional": false,
+                    "documentation": "Line position in a document (zero-based)."
                 },
                 {
-                    "name": "ClassMember",
-                    "value": 1,
-                    "documentation": "Indicates if the declaration is a method (a function defined within a class)."
-                },
-                {
-                    "name": "Constant",
-                    "value": 2,
-                    "documentation": "Indicates if the declaration is a constant (a variable that cannot be changed)."
-                },
-                {
-                    "name": "Final",
-                    "value": 4,
-                    "documentation": "Indicates if the declaration is final variable (a class that cannot be subclassed)."
-                },
-                {
-                    "name": "IsDefinedBySlots",
-                    "value": 8,
-                    "documentation": "Indicates if the declaration is defined by slots (a class that uses __slots__)."
-                },
-                {
-                    "name": "UsesLocalName",
-                    "value": 16,
-                    "documentation": "Indicates if the import declaration uses 'as' with a different name."
-                },
-                {
-                    "name": "UnresolvedImport",
-                    "value": 32,
-                    "documentation": "Indicates if the import declaration is unresolved (the module or symbol could not be found)."
-                },
-                {
-                    "name": "SimpleParam",
-                    "value": 64,
-                    "documentation": "Indicates if the declaration is a simple parameter (e.g., a function parameter)."
-                },
-                {
-                    "name": "ArgsListParam",
-                    "value": 128,
-                    "documentation": "Indicates if a declaration is an argument list (e.g., `*args`)."
-                },
-                {
-                    "name": "KwargsDictParam",
-                    "value": 256,
-                    "documentation": "Indicates if the declaration is a keyword argument dictionary (e.g., `**kwargs`)."
-                },
-                {
-                    "name": "PositionalParam",
-                    "value": 512,
-                    "documentation": "Indicates if the declaration is a positional parameter."
-                },
-                {
-                    "name": "StandardParam",
-                    "value": 1024,
-                    "documentation": "Indicates if the declaration is a standard parameter."
-                },
-                {
-                    "name": "KeywordParam",
-                    "value": 2048,
-                    "documentation": "Indicates if the declaration is a keyword parameter."
-                },
-                {
-                    "name": "ExpandedArgsParam",
-                    "value": 4096,
-                    "documentation": "Indicates if the declaration is an expanded *args parameter."
-                },
-                {
-                    "name": "ReturnType",
-                    "value": 8192,
-                    "documentation": "Indicates if the declaration is a return type (e.g., the return value of a function)."
-                },
-                {
-                    "name": "EnumMember",
-                    "value": 16384,
-                    "documentation": "Indicates if the declaration is a member of an enum type."
-                },
-                {
-                    "name": "TypeDeclared",
-                    "value": 32768,
-                    "documentation": "Indicates if the declaration has an explicitly declared type."
-                },
-                {
-                    "name": "SpecializedType",
-                    "value": 65536,
-                    "documentation": "Indicates if the declaration is a specialization of a generic type."
+                    "name": "character",
+                    "type": {
+                        "kind": "base",
+                        "name": "uinteger"
+                    },
+                    "optional": false,
+                    "documentation": "Character offset on a line in a document (zero-based)."
                 }
             ],
-            "documentation": "Flags that describe extra information about a declaration."
+            "documentation": "Position in a text document expressed as zero-based line and character offset."
         },
-        {
-            "name": "SymbolSearchFlags",
+        "LiteralValue": {
+            "kind": "alias",
             "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
-                {
-                    "name": "None",
-                    "value": 0
-                },
-                {
-                    "name": "SkipInstanceAttributes",
-                    "value": 1,
-                    "documentation": "Skip instance attributes when searching for attributes of a type."
-                },
-                {
-                    "name": "SkipTypeBaseClass",
-                    "value": 2,
-                    "documentation": "Skip members from the base class of a type when searching for members of a type."
-                },
-                {
-                    "name": "SkipAttributeAccessOverrides",
-                    "value": 4,
-                    "documentation": "Skip attribute access overrides when searching for members of a type."
-                },
-                {
-                    "name": "GetBoundAttributes",
-                    "value": 8,
-                    "documentation": "Look for bound attributes when searching for attributes of a type. That is methods bound specifically to an instance."
-                },
-                {
-                    "name": "SkipUnreachableCode",
-                    "value": 16,
-                    "documentation": "When searching for a name, skip symbols that are in unreachable code."
-                }
-            ],
-            "documentation": "Flags that are used for searching for symbols."
+                "kind": "or",
+                "items": [
+                    {
+                        "kind": "base",
+                        "name": "number"
+                    },
+                    {
+                        "kind": "base",
+                        "name": "boolean"
+                    },
+                    {
+                        "kind": "base",
+                        "name": "string"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "EnumLiteral"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "SentinelLiteral"
+                    }
+                ]
+            }
         },
-        {
-            "name": "SymbolFlags",
+        "Declaration": {
+            "kind": "alias",
             "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
-                {
-                    "name": "None",
-                    "value": 0
-                },
-                {
-                    "name": "SynthesizedName",
-                    "value": 1,
-                    "documentation": "Indicates if the symbol name was synthesized by the type server and not present in the source code."
-                }
-            ],
-            "documentation": "Flags that give more information about a symbol."
+                "kind": "or",
+                "items": [
+                    {
+                        "kind": "reference",
+                        "name": "RegularDeclaration"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "SynthesizedDeclaration"
+                    }
+                ]
+            }
         },
-        {
-            "name": "TypeReprFlags",
-            "type": {
-                "kind": "base",
-                "name": "integer"
-            },
-            "values": [
-                {
-                    "name": "None",
-                    "value": 0
-                },
-                {
-                    "name": "ExpandTypeAliases",
-                    "value": 1,
-                    "documentation": "Turn type aliases into their original type."
-                },
-                {
-                    "name": "PrintTypeVarVariance",
-                    "value": 2,
-                    "documentation": "Print the variance of a type parameter."
-                },
-                {
-                    "name": "ConvertToInstanceType",
-                    "value": 4,
-                    "documentation": "Convert the type into an instance type before printing it."
-                },
-                {
-                    "name": "PythonSyntax",
-                    "value": 8,
-                    "documentation": "Limit output to legal Python syntax."
-                }
-            ],
-            "documentation": "Flags that control how type representations are formatted."
-        }
-    ],
-    "typeAliases": [
-        {
-            "name": "FetchPropertyFlags",
+        "TypeVarType": {
+            "kind": "alias",
             "type": {
                 "kind": "reference",
-                "name": "FetchPropertiesFlags"
-            },
-            "documentation": "Alias for FetchPropertiesFlags provided for consumer convenience."
+                "name": "DeclaredType"
+            }
         },
-        {
-            "name": "TypeHandle",
+        "Type": {
+            "kind": "alias",
             "type": {
                 "kind": "or",
                 "items": [
                     {
-                        "kind": "base",
-                        "name": "string"
+                        "kind": "reference",
+                        "name": "BuiltInType"
                     },
                     {
-                        "kind": "base",
-                        "name": "integer"
-                    }
-                ]
-            },
-            "documentation": "Unique identifier for a type definition within the snapshot. A handle doesn't need to exist beyond the lifetime of the snapshot."
-        },
-        {
-            "name": "DeclarationHandle",
-            "type": {
-                "kind": "or",
-                "items": [
-                    {
-                        "kind": "base",
-                        "name": "string"
+                        "kind": "reference",
+                        "name": "DeclaredType"
                     },
                     {
-                        "kind": "base",
-                        "name": "integer"
+                        "kind": "reference",
+                        "name": "FunctionType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "ClassType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "UnionType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "ModuleType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "TypeVarType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "OverloadedType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "SynthesizedType"
+                    },
+                    {
+                        "kind": "reference",
+                        "name": "TypeReferenceType"
                     }
                 ]
-            },
-            "documentation": "Unique identifier for a declaration within the session."
+            }
         }
-    ]
+    }
 }

--- a/docs/tsp/type-server-protocol.md
+++ b/docs/tsp/type-server-protocol.md
@@ -1,8 +1,8 @@
 # Type Server Protocol
 
-The Type Server Protocol (TSP) is a JSON-RPC protocol for asking a type server for Python analysis data. A type server maintains the type-analysis state for a workspace and answers requests for snapshots, import resolution, diagnostics, type information, symbols, overloads, and related metadata.
+The Type Server Protocol (TSP) is a JSON-RPC protocol for asking a type server for Python analysis data. A type server maintains the type-analysis state for a workspace and answers requests for the protocol version, snapshots, Python search paths, import resolution, and type queries (computed, declared, and expected types).
 
-The protocol uses Language Server Protocol (LSP) data shapes where they are useful, such as `URI`, `Position`, `Range`, and `Diagnostic`. TSP methods use the `typeServer/` prefix.
+The protocol uses Language Server Protocol (LSP) data shapes and conventions where they are useful, such as `Position` and `Range`, and it represents URIs as strings the same way LSP does. TSP methods use the `typeServer/` prefix.
 
 The protocol artifacts in this folder are the authoritative definitions:
 
@@ -38,7 +38,7 @@ A typical session follows this order:
 1. The client and server initialize any shared workspace state, commonly through the LSP `initialize` and `initialized` messages.
 1. The client calls `typeServer/getSupportedProtocolVersion` and verifies that the returned semver string is compatible with the protocol version it expects.
 1. The client calls `typeServer/getSnapshot` to obtain the first snapshot identifier.
-1. The client sends type, import, symbol, diagnostic, or metadata requests that include the current snapshot when required by the request shape.
+1. The client sends type-query, import-resolution, or search-path requests that include the current snapshot when required by the request shape.
 1. The server sends `typeServer/snapshotChanged` when prior type results are no longer valid.
 
 ## Multi-Connection Mode
@@ -139,7 +139,7 @@ The main connection owns all state-changing traffic. The following must remain m
 
 - LSP initialization and lifecycle messages.
 - Workspace, configuration, file-watcher, and document synchronization notifications.
-- Server-to-client snapshot and diagnostics notifications.
+- Server-to-client snapshot notifications.
 - The `typeServer/connection` control request.
 
 Extra connections are TSP-only and read-only. They may be used for requests that do not mutate server state and whose results are valid for the snapshot supplied by the client.
@@ -185,13 +185,28 @@ If a type server stores source locations in another encoding, it must convert lo
 
 ## Nodes, Declarations, And Handles
 
-Many requests identify source constructs by node, declaration, type handle, or symbol handle. A node is a URI plus a source range. A declaration describes where and how a symbol is defined. Handles identify protocol objects that the type server can resolve within the current snapshot.
+The type-query requests (`typeServer/getComputedType`, `typeServer/getDeclaredType`, `typeServer/getExpectedType`) identify a source construct with an `arg` that is either a node or a declaration. A node is a URI plus a source range. A declaration describes where and how a symbol is defined and is either a regular declaration, which is backed by a source AST node, or a synthesized declaration, which is created by the type checker and has no source node.
 
 `InvalidHandle` is `-1` and represents an invalid or unavailable handle. Clients and servers should treat it as a sentinel value, not as a valid object identifier.
 
 ## Type Results
 
 Type results are JSON-serializable tagged objects. Each type includes a discriminator that tells the client how to interpret the rest of the object. The protocol supports built-in types, declared types, functions, classes, unions, modules, type variables, overload sets, synthesized types, and type references.
+
+Every type object carries a numeric `kind` discriminator, a numeric `id`, and a bitfield of `flags`:
+
+| `kind` | Type            | Description                                                          |
+| ------ | --------------- | ------------------------------------------------------------------- |
+| `0`    | `BuiltIn`       | `unknown`, `any`, `unbound`, `ellipsis`, `never`, and similar       |
+| `1`    | `Declared`      | Base for source-declared types (rarely used directly)               |
+| `2`    | `Function`      | Functions and methods from `def` statements                         |
+| `3`    | `Class`         | Classes and their instances                                         |
+| `4`    | `Union`         | Union types (`int \| str \| None`)                                  |
+| `5`    | `Module`        | Module objects (`import os` produces a `Module` type for `os`)      |
+| `6`    | `TypeVar`       | Type variables (`T`, `P`, `Ts`)                                     |
+| `7`    | `Overloaded`    | Functions with multiple `@overload` signatures                      |
+| `8`    | `Synthesized`   | Types synthesized by the type checker                               |
+| `9`    | `TypeReference` | Reference to another type by `id`, used for deduplication and cycles |
 
 Type objects are snapshot-bound, and type IDs are response-local:
 
@@ -202,20 +217,29 @@ Type objects are snapshot-bound, and type IDs are response-local:
 
 ## Protocol Surface
 
-The exact parameters and result shapes are defined in the protocol artifacts. At a high level, TSP includes these categories of messages:
+The current protocol is intentionally small. The exact parameters and result shapes are defined in the protocol artifacts; the table below lists every TSP message with its direction and payload shape.
 
-| Category                     | Messages                                                                                                                                                                       |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Compatibility and state      | `typeServer/getSupportedProtocolVersion`, `typeServer/getSnapshot`, `typeServer/snapshotChanged`                                                                               |
-| Connection control           | `typeServer/connection`                                                                                                                                                        |
-| Diagnostics                  | `typeServer/getDiagnostics`, `typeServer/getDiagnosticsVersion`, `typeServer/diagnosticsChanged`                                                                               |
-| Import and search paths      | `typeServer/getPythonSearchPaths`, `typeServer/resolveImport`, `typeServer/resolveImportDeclaration`                                                                           |
-| Type queries                 | `typeServer/getType`, `typeServer/getComputedType`, `typeServer/getDeclaredType`, `typeServer/getExpectedType`, `typeServer/getBuiltinType`, `typeServer/getTypeOfDeclaration` |
-| Type structure               | `typeServer/getTypeArgs`, `typeServer/getTypeAliasInfo`, `typeServer/combineTypes`, `typeServer/createInstanceType`, `typeServer/fetchTypeProperties`                          |
-| Symbols and callable details | `typeServer/getSymbolsForType`, `typeServer/getSymbolsForNode`, `typeServer/getOverloads`, `typeServer/getMatchingOverloads`, `typeServer/getMetaclass`                        |
-| Display metadata             | `typeServer/getRepr`, `typeServer/getDocString`                                                                                                                                |
+| Message                                  | Direction       | Params                                       | Result                  |
+| ---------------------------------------- | --------------- | -------------------------------------------- | ----------------------- |
+| `typeServer/getSupportedProtocolVersion` | client → server | none                                         | `string` (semver)       |
+| `typeServer/getSnapshot`                 | client → server | none                                         | `number`                |
+| `typeServer/snapshotChanged`             | server → client | `{ old: number, new: number }`               | notification            |
+| `typeServer/connection`                  | client → server | `{ type: "open" \| "close", kind, args? }`   | `{ success, message? }` |
+| `typeServer/getPythonSearchPaths`        | client → server | `{ fromUri, snapshot }`                       | `string[] \| undefined` |
+| `typeServer/resolveImport`               | client → server | `{ sourceUri, moduleDescriptor, snapshot }`   | `string \| undefined`   |
+| `typeServer/getComputedType`             | client → server | `{ arg: Declaration \| Node, snapshot }`      | `Type \| undefined`     |
+| `typeServer/getDeclaredType`             | client → server | `{ arg: Declaration \| Node, snapshot }`      | `Type \| undefined`     |
+| `typeServer/getExpectedType`             | client → server | `{ arg: Declaration \| Node, snapshot }`      | `Type \| undefined`     |
 
-A type server should implement the messages required by the client it integrates with and return `null` or `undefined` only where the protocol's result type allows it.
+A type server should implement the messages required by the client it integrates with and return `undefined` only where the protocol's result type allows it.
+
+### Type Queries
+
+The three type-query requests differ by which type they report for the same node or declaration:
+
+- `typeServer/getComputedType` returns the type inferred from code flow. After narrowing `a` to `int`, the computed type of `b` in `b = a + 1` is `int`.
+- `typeServer/getDeclaredType` returns the type explicitly written in the source. For `def foo(a: int | str)`, the declared type of `a` is `int | str`.
+- `typeServer/getExpectedType` returns the type the surrounding context expects. For the call `foo(4)`, the expected type of the argument is `int | str`.
 
 ## Error Handling
 
@@ -240,6 +264,6 @@ A compatible type server should verify these behaviors:
 1. Requests with stale snapshots fail with a retryable cancellation error.
 1. Position and range conversions use LSP zero-based UTF-16 conventions.
 1. Import-resolution requests return document URIs or no result according to the protocol result type.
-1. Type, symbol, overload, diagnostic, and display requests return well-formed objects for the snapshot supplied by the client.
+1. Type queries (computed, declared, and expected) return well-formed `Type` objects, or `undefined`, for the snapshot supplied by the client.
 1. Multi-connection support is advertised only when the server can serve the negotiated extra transport.
 1. Extra connections accept every TSP request allowed for the negotiated TSP version and reject LSP traffic, state-changing notifications, `typeServer/connection`, and TSP requests not allowed for that version.


### PR DESCRIPTION
## Summary

`docs/tsp/type-server-protocol.md` and `docs/tsp/tsp.json` were out of date with respect to the current Type Server Protocol as defined in [microsoft/pyrx](https://github.com/microsoft/pyrx). The protocol was trimmed to **8 requests + 1 notification** (version `0.4.1`), but the docs still described the older ~40-method surface (diagnostics, symbols, overloads, display metadata, type-structure operations, etc.).

Note: `typeServerProtocol.ts` and `tsp.schema.json` were already in sync with pyrx and needed no changes — only `tsp.json` and the markdown were stale.

## Changes

**`docs/tsp/tsp.json`** — synced with pyrx's authoritative model. Now lists the 8 current requests plus `snapshotChanged`, down from 23 requests.

**`docs/tsp/type-server-protocol.md`**
- Rewrote the **Protocol Surface** table from ~40 methods to the actual 9 messages, each with direction, params, and result shapes.
- Added a **Type Queries** subsection explaining computed vs. declared vs. expected types.
- Added a **type-kind discriminator table** (`0` `BuiltIn` … `9` `TypeReference`).
- Updated the intro, startup sequence, "Nodes, Declarations, And Handles" (removed the defunct "symbol handle"; described `arg: Declaration | Node`), allowed-traffic notes, the LSP-shapes reference (dropped `Diagnostic`), and the compatibility checklist to drop references to removed diagnostics/symbols/overloads/display methods.

The current protocol surface:
`getSupportedProtocolVersion`, `getSnapshot`, `snapshotChanged`, `connection`, `getPythonSearchPaths`, `resolveImport`, `getComputedType`, `getDeclaredType`, `getExpectedType`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>