### PR TITLE
Update exclude/include docs for additive default excludes

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -64,6 +64,7 @@ Each page explains one `python.analysis.*` setting: what it does, accepted value
 | ---------------------------------------------- | --------------------------------------------- |
 | [include](settings/python_analysis_include.md) | Files and directories to analyze              |
 | [exclude](settings/python_analysis_exclude.md) | Files and directories to skip                 |
+| [useDefaultExcludes](settings/python_analysis_useDefaultExcludes.md) | Toggle the built-in default exclusions (defaults are additive) |
 | [ignore](settings/python_analysis_ignore.md)   | Files to analyze but suppress diagnostics for |
 
 ### Indexing and Completions

--- a/docs/howto/monorepo-setup.md
+++ b/docs/howto/monorepo-setup.md
@@ -887,13 +887,15 @@ This completely prevents Pylance from creating an analyzer for that folder, savi
 
 ### Exclude Patterns
 
-> **Warning**: Setting [`python.analysis.exclude`](../settings/python_analysis_exclude.md) **overrides** (not appends to) the defaults. If you customize it, include the defaults explicitly:
+> **Note**: Setting [`python.analysis.exclude`](../settings/python_analysis_exclude.md) is **additive** — your entries are added on top of the default exclusions (`**/node_modules`, `**/__pycache__`, dotfiles, and auto-detected virtual environments) rather than replacing them. You only need to list the extra paths you want excluded:
 >
 > ```json
 > {
->     "python.analysis.exclude": ["**/node_modules", "**/__pycache__", "**/.*", "packages/legacy/**", "data/**"]
+>     "python.analysis.exclude": ["packages/legacy/**", "data/**"]
 > }
 > ```
+>
+> To turn the built-in default exclusions off entirely (for example, to analyze a directory that was incorrectly auto-detected as a virtual environment), set [`python.analysis.useDefaultExcludes`](../settings/python_analysis_useDefaultExcludes.md) to `false`.
 
 ### Monorepo Performance Presets
 

--- a/docs/howto/performance-tuning.md
+++ b/docs/howto/performance-tuning.md
@@ -101,7 +101,7 @@ In multi-root workspaces, you can also **exclude entire workspace folders** you'
 }
 ```
 
-> **Note**: Virtual environments (`.venv`, `venv`, etc.) are auto-excluded by default. You don't need to add them to `exclude` manually.
+> **Note**: The built-in defaults (`**/node_modules`, `**/__pycache__`, dotfiles, and auto-detected virtual environments like `.venv` / `venv`) are excluded **by default**, and your `exclude` entries are added on top of them. You don't need to re-list the defaults to keep them excluded. To turn the built-in defaults off, set [`python.analysis.useDefaultExcludes`](../settings/python_analysis_useDefaultExcludes.md) to `false`.
 
 > **Note**: If [`pyrightconfig.json`](https://microsoft.github.io/pyright/#/configuration) or `pyproject.toml` with `[tool.pyright]` exists, the VS Code `exclude` setting is **ignored** — set `exclude` in the config file instead. See [How to Troubleshoot Pylance Settings](settings-troubleshooting.md).
 

--- a/docs/settings/python_analysis_exclude.md
+++ b/docs/settings/python_analysis_exclude.md
@@ -12,18 +12,38 @@ The `python.analysis.exclude` setting in Pylance specifies paths to directories 
 
 ### Default Behavior
 
-By default, Pylance automatically excludes certain directories from workspace to optimize performance. These default exclusions are:
+By default, Pylance excludes certain directories from the workspace to optimize performance. These default exclusions are:
 
 - `**/node_modules`
 - `**/__pycache__`
-- `.*` directories
-- Virtual environment directories (e.g., those containing `bin/activate`, `Scripts/activate`, or `pyvenv.cfg`)
+- `**/__editable__.*`
+- Hidden directories (dotfiles), i.e. any directory whose name begins with a `.` (for example `.git`, `.venv`, `.tox`)
+- Auto-detected virtual environment directories (e.g., those containing `bin/activate`, `Scripts/activate`, or `pyvenv.cfg`)
 
-This means that unless you specify your own exclusions, Pylance will ignore these directories.
+These built-in exclusions are controlled by [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md), which is enabled by default. They are applied *in addition to* any paths you set in `python.analysis.exclude` (see [Customizing Exclusions](#customizing-exclusions) below).
 
 ### Customizing Exclusions
 
-When you specify the `python.analysis.exclude` setting in your `settings.json`, Pylance will **override** the default exclusions. This means that if you customize this setting, you need to explicitly include the default exclusions if you still want them to be ignored including virtual environments.
+The `python.analysis.exclude` setting is **additive**: any paths you specify are added *on top of* the default exclusions rather than replacing them. Specifying your own excludes never disables the built-in ones, so you do **not** need to repeat the defaults (such as `**/node_modules` or your virtual environment) to keep them excluded.
+
+> **Note**: This is a change from older versions of Pylance, where specifying any custom exclude path silently dropped the built-in default exclusions and virtual-environment auto-detection. Custom excludes are now always additive, similar to VS Code's `files.exclude` and `search.exclude`. You can turn the built-in defaults off entirely with [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md).
+
+### Precedence Over `include`
+
+The default exclusions take precedence over [`python.analysis.include`](python_analysis_include.md). This means a directory that Pylance auto-detects as a virtual environment (or that matches another default exclusion) stays excluded **even if you explicitly list it in `include`**. Adding a path to `include` does not override the built-in excludes.
+
+### Turning Off the Built-in Defaults
+
+If you need Pylance to analyze a directory that a default exclusion is skipping — for example, a directory that was incorrectly auto-detected as a virtual environment — set [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md) to `false`. This disables **all** of the built-in default exclusions (including virtual-environment auto-detection), so only the paths you list in `python.analysis.exclude` are excluded:
+
+```json
+{
+    "python.analysis.useDefaultExcludes": false,
+    "python.analysis.exclude": ["**/node_modules", "**/build"]
+}
+```
+
+Because this turns off every built-in exclude, you'll typically want to re-add the ones you still care about (such as `**/node_modules`) to `python.analysis.exclude` yourself. Disabling the defaults can slow analysis significantly in workspaces that contain large dependency or environment directories.
 
 ## How to Use `python.analysis.exclude`
 
@@ -44,9 +64,11 @@ Example:
 
 ```json
 {
-    "python.analysis.exclude": ["**/node_modules", "**/__pycache__", ".git", "**/build", "env/**"]
+    "python.analysis.exclude": ["**/build", "env/**"]
 }
 ```
+
+Because the default exclusions are always applied, you only need to list the *additional* paths you want to exclude — the defaults (`**/node_modules`, `**/__pycache__`, dotfiles, virtual environments, etc.) remain excluded automatically.
 
 ### Specifying Paths
 
@@ -59,7 +81,7 @@ Example:
 
 ### Caveats
 
-- **Overriding Defaults**: Remember that setting `python.analysis.exclude` overrides the default exclusions. If you want to keep the defaults, you need to include them explicitly.
+- **Defaults Are Additive**: Paths you set in `python.analysis.exclude` are added on top of the default exclusions — they do not replace them. You don't need to re-list the defaults to keep them excluded.
 - **Excluded Files May Still Be Processed**: If an excluded file is imported by a file that is included in the workspace, Pylance may still process the excluded file to provide IntelliSense and type checking for the importing file.
 - **Opened Files**: Even if a file is in the excluded paths, if you open it in the editor, Pylance will provide analysis for that file.
 
@@ -81,13 +103,15 @@ The `python.analysis.ignore` setting specifies paths whose diagnostic output (er
 
 ### Excluding Specific Directories
 
-To exclude directories like `build`, `env`, and keep the default exclusions, your settings might look like:
+To exclude directories like `build` and `env`, your settings might look like:
 
 ```json
 {
-    "python.analysis.exclude": ["**/node_modules", "**/__pycache__", ".git", "**/build", "env/**"]
+    "python.analysis.exclude": ["**/build", "env/**"]
 }
 ```
+
+The default exclusions (`**/node_modules`, `**/__pycache__`, dotfiles, virtual environments, etc.) remain in effect automatically, so you don't need to list them here.
 
 ### Excluding All Files Except Opened Ones
 
@@ -142,13 +166,15 @@ If your workspace includes generated code or external libraries that you do not 
 
 ### Virtual Environments Inside the Workspace
 
-If your virtual environment is located within your workspace (e.g., `./venv`), and you customize `python.analysis.exclude`, you need to exclude your virtual environment directory explicitly:
+Virtual environments are auto-detected and excluded by default, so a venv located inside your workspace (e.g., `./venv`) is excluded automatically — even when you specify other custom excludes. You do **not** need to list it explicitly:
 
 ```json
 {
-    "python.analysis.exclude": ["**/node_modules", "**/__pycache__", ".git", "venv/**"]
+    "python.analysis.exclude": ["**/build"]
 }
 ```
+
+In the rare case that Pylance misdetects a regular directory as a virtual environment, note that adding it to `python.analysis.include` will **not** rescue it — the default exclusions take precedence over `include`. Instead, set [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md) to `false` to turn off the built-in excludes (including virtual-environment auto-detection).
 
 ## Frequently Asked Questions
 
@@ -162,7 +188,11 @@ Yes, excluding unnecessary files and directories can improve Pylance's performan
 
 ### What happens if I specify `python.analysis.exclude` and don't include the default exclusions?
 
-If you specify `python.analysis.exclude` without including the default exclusions, Pylance will stop automatically excluding the default directories (`**/node_modules`, `**/__pycache__`, `.git`, and virtual environments). You need to include them explicitly if you still want them excluded.
+Nothing changes for the defaults — they're always applied. Custom excludes are **additive**: the paths you specify are added on top of the default exclusions (`**/node_modules`, `**/__pycache__`, `**/__editable__.*`, dotfiles, and virtual environments), which stay excluded automatically. You don't need to re-list them. To turn the defaults off entirely, use [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md).
+
+### Pylance excluded a directory that isn't a virtual environment. How do I get it analyzed again?
+
+Virtual-environment detection is a heuristic, so Pylance can occasionally treat a regular directory as a virtual environment and exclude it. Because the default exclusions take precedence over `include`, adding the directory to [`python.analysis.include`](python_analysis_include.md) will **not** rescue it. Instead, set [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md) to `false`, which disables all built-in excludes (including virtual-environment auto-detection) so only your explicit `python.analysis.exclude` paths apply.
 
 ### How can I exclude all files and only analyze open files?
 
@@ -191,6 +221,7 @@ The pattern `**/src/**` does not match `src/` because there is no folder precedi
 
 ## Related Settings
 
+- [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md): Turns the built-in default exclusions on or off.
 - [`python.analysis.include`](python_analysis_include.md): Controls which files are included in analysis.
 - [`python.analysis.ignore`](python_analysis_ignore.md): Suppresses diagnostics without excluding files.
 - [`python.analysis.diagnosticMode`](python_analysis_diagnosticMode.md): Controls whether diagnostics run on all files or only open files.

--- a/docs/settings/python_analysis_include.md
+++ b/docs/settings/python_analysis_include.md
@@ -23,6 +23,8 @@ The `python.analysis.include` setting in Pylance allows you to specify paths to 
 
 - **Interaction with `exclude`**: The `python.analysis.exclude` setting specifies paths to directories or files that Pylance should ignore, even if they are included in `include`. Paths specified in `exclude` take precedence over those in `include`. This allows you to fine-tune which parts of your included directories should be ignored.
 
+- **Default Exclusions Take Precedence Over `include`**: Pylance's built-in default exclusions — `**/node_modules`, `**/__pycache__`, `**/__editable__.*`, hidden directories (dotfiles), and auto-detected virtual environment directories — also take precedence over `include`. This means a directory that Pylance auto-detects as a virtual environment stays excluded even if you name it explicitly in `include`. To force analysis of such a directory, turn the built-in defaults off with [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md) rather than adding it to `include`.
+
 ## How to Use `python.analysis.include`
 
 You can modify the `python.analysis.include` setting in your VS Code settings, either globally (User settings) or for your workspace.
@@ -154,6 +156,10 @@ Your project may contain directories with generated code, build artifacts, or ex
 - You haven't overridden the default include paths without including the workspace root (if needed).
 - There are no conflicting settings in [`python.analysis.exclude`](python_analysis_exclude.md) that might be excluding the files you want to include.
 
+### Q: Pylance auto-excluded a directory as a virtual environment. Can I use `include` to analyze it anyway?
+
+**A:** No. Pylance always auto-excludes directories it detects as virtual environments, and the built-in default exclusions take precedence over `include`, so naming the directory in `python.analysis.include` will not bring it back. To force analysis of a directory that a default exclusion is skipping, set [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md) to `false`. This disables all built-in excludes — including virtual-environment auto-detection — so only the paths listed in [`python.analysis.exclude`](python_analysis_exclude.md) are excluded.
+
 ### Q: Can users use `${workspaceFolder:rootName}` in `include/exclude/ignore`, and when would they use it?
 
 **A:** Yes, `${workspaceFolder:rootName}` can be used. In a multi-root workspace, if you want to specify `include`, `exclude`, or `ignore` settings for each workspace root individually, you can prefix those settings with `${workspaceFolder:rootName}` to indicate which root the setting applies to.
@@ -202,6 +208,7 @@ These methods offer flexibility for managing analysis settings per workspace roo
 ## Related Settings
 
 - [`python.analysis.exclude`](python_analysis_exclude.md): Controls which files are excluded from analysis.
+- [`python.analysis.useDefaultExcludes`](python_analysis_useDefaultExcludes.md): Turns the built-in default exclusions on or off.
 - [`python.analysis.ignore`](python_analysis_ignore.md): Suppresses diagnostics for specific paths without excluding them.
 - [`python.analysis.extraPaths`](python_analysis_extraPaths.md): Adds directories to the import search path.
 

--- a/docs/settings/python_analysis_useDefaultExcludes.md
+++ b/docs/settings/python_analysis_useDefaultExcludes.md
@@ -1,0 +1,84 @@
+# Understanding `python.analysis.useDefaultExcludes` in Pylance
+
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) is a fast and feature-rich language server extension for Python in Visual Studio Code, powered by the Pyright static type checker.
+
+The `python.analysis.useDefaultExcludes` setting controls whether Pylance applies its built-in default exclusions in addition to the paths you list in [`python.analysis.exclude`](python_analysis_exclude.md).
+
+## What Is `python.analysis.useDefaultExcludes`?
+
+To keep analysis fast, Pylance excludes a set of directories that rarely need to be analyzed. When this setting is enabled (the default), those built-in exclusions are applied **in addition to** any paths you specify in [`python.analysis.exclude`](python_analysis_exclude.md).
+
+The built-in default exclusions are:
+
+- `**/node_modules`
+- `**/__pycache__`
+- `**/__editable__.*`
+- Hidden directories (dotfiles), i.e. any directory whose name begins with a `.` (for example `.git`, `.venv`, `.tox`)
+- Auto-detected virtual environment directories (e.g., those containing `bin/activate`, `Scripts/activate`, or `pyvenv.cfg`)
+
+These defaults take precedence over [`python.analysis.include`](python_analysis_include.md), so a directory that Pylance auto-detects as a virtual environment stays excluded even if you name it explicitly in `include`.
+
+**Type**: `boolean`
+**Default**: `true`
+**Scope**: resource (can be set per workspace folder)
+
+## Behavior
+
+### When enabled (`true`, the default)
+
+The built-in default exclusions listed above are applied on top of your `python.analysis.exclude` entries. Your custom excludes are **additive** — they add to the defaults rather than replacing them — so you never need to re-list the defaults to keep them excluded.
+
+### When disabled (`false`)
+
+All of the built-in default exclusions are turned off, **including virtual-environment auto-detection**. Only the paths you list in [`python.analysis.exclude`](python_analysis_exclude.md) are excluded.
+
+> **Note**: Disabling the built-in excludes can slow analysis significantly if your workspace contains large dependency or virtual-environment directories, because Pylance will then analyze them unless you exclude them yourself.
+
+## How to Change `python.analysis.useDefaultExcludes`
+
+### Using the Settings UI
+
+1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run **Preferences: Open Settings (UI)**.
+2. Search for `python.analysis.useDefaultExcludes`.
+3. Check or uncheck the box.
+
+### Using `settings.json`
+
+```json
+{
+    "python.analysis.useDefaultExcludes": false
+}
+```
+
+## When to Use It
+
+- **Keep enabled** (the default) for almost all projects. The built-in excludes keep analysis fast and rarely need to change, and your own `python.analysis.exclude` entries are added on top of them.
+- **Disable** when a default exclusion is skipping a directory you need analyzed — most commonly a directory that was incorrectly auto-detected as a virtual environment. Because the defaults take precedence over `include`, turning this setting off is the way to force analysis of such a directory; adding it to `include` will not.
+
+When you disable the defaults, you'll typically want to re-add the exclusions you still care about (such as `**/node_modules` and your real virtual environment) to `python.analysis.exclude` yourself:
+
+```json
+{
+    "python.analysis.useDefaultExcludes": false,
+    "python.analysis.exclude": ["**/node_modules", "**/__pycache__", "venv/**"]
+}
+```
+
+## Related Settings
+
+- [`python.analysis.exclude`](python_analysis_exclude.md): Paths to exclude from analysis; combined with the built-in defaults this setting controls.
+- [`python.analysis.include`](python_analysis_include.md): Paths to include in analysis. The built-in default exclusions take precedence over `include`.
+- [`python.analysis.ignore`](python_analysis_ignore.md): Suppresses diagnostics for specific paths without excluding them.
+
+## See Also
+
+- [How to Set Up a Python Monorepo](../howto/monorepo-setup.md) — per-subfolder exclusion patterns
+- [How to Tune Pylance Performance](../howto/performance-tuning.md) — using excludes to reduce analysis scope
+
+---
+
+_For more information on Pylance settings and customization, refer to the **[Pylance Settings and Customization](https://code.visualstudio.com/docs/python/settings-reference)** documentation._
+
+---
+
+_This document was generated with the assistance of AI and has been reviewed by humans for accuracy and completeness._


### PR DESCRIPTION
## Summary

Updates the Pylance docs to match the new behavior in [microsoft/pyrx#9040](https://github.com/microsoft/pyrx/pull/9040), which changes how `python.analysis.exclude` interacts with the built-in default exclusions.

### Behavior being documented
- `python.analysis.exclude` is now **additive**: the built-in default excludes (`**/node_modules`, `**/__pycache__`, `**/__editable__.*`, hidden directories/dotfiles, and auto-detected virtual environment directories) are applied *on top of* user-specified excludes rather than being replaced when the user specifies any custom exclude.
- A new setting **`python.analysis.useDefaultExcludes`** (boolean, default `true`) toggles the built-in default excludes. Setting it to `false` disables all of them, including virtual-environment auto-detection.
- The built-in default exclusions **take precedence over `python.analysis.include`**, so a directory auto-detected as a virtual environment stays excluded even if it's explicitly included. To force analysis of such a directory, set `useDefaultExcludes` to `false`.

## Changes
- **`docs/settings/python_analysis_exclude.md`** — rewrote the default-behavior, customizing, precedence, examples, virtual-environment, and FAQ sections to describe additive behavior and the new `useDefaultExcludes` escape hatch.
- **`docs/settings/python_analysis_include.md`** — clarified that default exclusions take precedence over `include`, and how to force analysis via `useDefaultExcludes`.
- **`docs/settings/python_analysis_useDefaultExcludes.md`** — new dedicated settings doc.
- **`docs/INDEX.md`** — added `useDefaultExcludes` to the Files & Directories settings table.
- **`docs/howto/monorepo-setup.md`** — corrected the outdated "overrides (not appends)" warning to describe additive behavior and mention `useDefaultExcludes`.
- **`docs/howto/performance-tuning.md`** — updated the auto-exclude note.

Related: addresses documentation for microsoft/pylance-release#5970.