### PR TITLE
Add Pylance/Pyright type-checking skills package

### DIFF
--- a/skill/README.md
+++ b/skill/README.md
@@ -1,0 +1,36 @@
+# Pylance / Pyright Type-Checking Skills
+
+A package of Claude Code skills for Python type checking with **Pylance** and **Pyright**. This repo is the `pylance-release` docs corpus, so every skill here is a thin, triggered entry point that **links into the real documentation** under [`../docs/`](../docs/INDEX.md) rather than duplicating it. Read the skill, then follow the relative links to the authoritative page.
+
+## Skills
+
+| Skill | Use when |
+| ----- | -------- |
+| [pylance-type-checking-setup](pylance-type-checking-setup/SKILL.md) | Configuring strictness/scope: `typeCheckingMode`, `diagnosticSeverityOverrides`, `languageServerMode`, `pyrightVersion`, config-file precedence |
+| [pylance-import-resolution](pylance-import-resolution/SKILL.md) | `Import "..." could not be resolved`, missing stubs, `extraPaths`/`stubPath`/`useLibraryCodeForTypes`, editable installs, interpreter selection |
+| [pylance-diagnostics-triage](pylance-diagnostics-triage/SKILL.md) | Decoding or suppressing a specific `report*` rule; `# pyright: ignore` / `# type: ignore`; per-rule severity |
+| [pylance-strict-migration](pylance-strict-migration/SKILL.md) | Moving from `off`/`basic` to `strict` incrementally; per-file/per-directory strict; quieting `reportUnknown*` |
+| [pylance-type-system-patterns](pylance-type-system-patterns/SKILL.md) | Authoring typing: type narrowing, `TypeGuard`/`TypeIs`, generics/`TypeVar`, `Protocol`, `TypedDict`, `Literal`, overloads, overrides |
+| [pylance-workspace-perf](pylance-workspace-perf/SKILL.md) | `diagnosticMode` (open files vs workspace), `include`/`exclude`/`ignore`, monorepo setup, performance/memory, logs, notebooks, remote |
+| [pylance-type-server-protocol](pylance-type-server-protocol/SKILL.md) | Building tooling that speaks the Type Server Protocol (`typeServer/*` JSON-RPC) |
+
+The authoritative master index of all docs is [`../docs/INDEX.md`](../docs/INDEX.md).
+
+## Installation / discovery
+
+Claude Code auto-discovers skills from `~/.claude/skills/` (user) or `.claude/skills/` (project). To install this package for your user, symlink each skill directory into `~/.claude/skills/`:
+
+```bash
+REPO=/opt/repo/pylance-agent-skill
+for s in "$REPO"/skill/pylance-*; do
+  ln -sf "$s" "$HOME/.claude/skills/$(basename "$s")"
+done
+```
+
+Because the symlinks point at `skill/` in this repo, the `SKILL.md` relative links (`../../docs/...`) keep resolving to the authoritative doc pages here. If you move or delete this repo, the links break — in that case copy each `skill/<name>` directory into `~/.claude/skills/<name>` instead and adjust the `../../docs/...` paths to absolute or repo-relative.
+
+## Conventions used in these skills
+
+- Bodies stay lean (progressive disclosure). Deeper detail lives in the linked doc pages.
+- Relative links to in-repo docs are written from the skill's `SKILL.md`: `../../docs/...` (two levels up to the repo root) and `../docs/...` from this `README.md`.
+- The deprecated root file `DIAGNOSTIC_SEVERITY_RULES.md` is **not** used as a rule source; the live rule set is `docs/diagnostics/` plus the mode table in `docs/settings/python_analysis_typeCheckingMode.md`.

--- a/skill/pylance-diagnostics-triage/SKILL.md
+++ b/skill/pylance-diagnostics-triage/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: pylance-diagnostics-triage
+description: Look up and fix individual Pylance/Pyright diagnostic rules (the report* family). Use when decoding a specific squiggle, suppressing a rule with "# pyright: ignore[...]" or "# type: ignore", or changing one rule's severity. Triggers on any "report..." rule name (reportArgumentType, reportMissingTypeStubs, reportOptionalMemberAccess, reportUnknownVariableType, reportIncompatibleMethodOverride, etc.) and on "pyright ignore", "type ignore", "what does this Pylance error mean".
+---
+
+# Pylance diagnostics triage
+
+Each Pyright/Pylance diagnostic rule has its own page under [../../docs/diagnostics/](../../docs/diagnostics/) with overview, representative issues, examples, and fixes. Use this grouped index to find the right page fast.
+
+## Suppression
+
+- File/line suppression: `# pyright: ignore[<ruleName>]` (or `# type: ignore`).
+- Disable a rule project-wide: set it to `"none"` in `diagnosticSeverityOverrides` — [../../docs/settings/python_analysis_diagnosticSeverityOverrides.md](../../docs/settings/python_analysis_diagnosticSeverityOverrides.md).
+- Mark unreachable-ignore analysis via `reportUnnecessaryTypeIgnoreComment`.
+
+## Which mode enables a rule
+
+A rule only fires if the active `typeCheckingMode` enables it **and** its severity isn't `none`. See the mode→rule table: [../../docs/settings/python_analysis_typeCheckingMode.md](../../docs/settings/python_analysis_typeCheckingMode.md).
+
+## Rule index (grouped)
+
+### Import / stub
+- [reportMissingImports](../../docs/diagnostics/reportMissingImports.md) — import cannot be resolved.
+- [reportMissingModuleSource](../../docs/diagnostics/reportMissingModuleSource.md) — module found but source/stub not available.
+- [reportMissingTypeStubs](../../docs/diagnostics/reportMissingTypeStubs.md) — no `.pyi`/`py.typed` for a module.
+- [reportIncompleteStub](../../docs/diagnostics/reportIncompleteStub.md) — stub present but incomplete.
+- [reportPrivateImportUsage](../../docs/diagnostics/reportPrivateImportUsage.md) — importing a name not in a module's public API.
+- [reportImportCycles](../../docs/diagnostics/reportImportCycles.md) — circular imports.
+- [reportDuplicateImport](../../docs/diagnostics/reportDuplicateImport.md) — same import twice.
+- [reportUnusedImport](../../docs/diagnostics/reportUnusedImport.md) — imported but never used.
+- [reportWildcardImportFromLibrary](../../docs/diagnostics/reportWildcardImportFromLibrary.md) — `from lib import *`.
+
+### Core type errors
+- [reportArgumentType](../../docs/diagnostics/reportArgumentType.md) — argument doesn't match parameter type.
+- [reportAssignmentType](../../docs/diagnostics/reportAssignmentType.md) — RHS type not assignable to LHS.
+- [reportReturnType](../../docs/diagnostics/reportReturnType.md) — return value type mismatch.
+- [reportAttributeAccessIssue](../../docs/diagnostics/reportAttributeAccessIssue.md) — attribute access invalid for the type.
+- [reportCallIssue](../../docs/diagnostics/reportCallIssue.md) — calling something that can't be called that way.
+- [reportIndexIssue](../../docs/diagnostics/reportIndexIssue.md) — invalid indexing/subscripting.
+- [reportOperatorIssue](../../docs/diagnostics/reportOperatorIssue.md) — operator not valid for the operand type(s).
+- [reportGeneralTypeIssues](../../docs/diagnostics/reportGeneralTypeIssues.md) — broad type-compatibility errors (older catch-all).
+
+### None-safety (Optional family)
+- [reportOptionalMemberAccess](../../docs/diagnostics/reportOptionalMemberAccess.md)
+- [reportOptionalCall](../../docs/diagnostics/reportOptionalCall.md)
+- [reportOptionalSubscript](../../docs/diagnostics/reportOptionalSubscript.md)
+- [reportOptionalIterable](../../docs/diagnostics/reportOptionalIterable.md)
+- [reportOptionalOperand](../../docs/diagnostics/reportOptionalOperand.md)
+- [reportOptionalContextManager](../../docs/diagnostics/reportOptionalContextManager.md)
+
+> Fix pattern: narrow with `is None` / `isinstance` before use — see `pylance-type-system-patterns`.
+
+### Unknown-type (strict-mode family)
+- [reportUnknownVariableType](../../docs/diagnostics/reportUnknownVariableType.md)
+- [reportUnknownArgumentType](../../docs/diagnostics/reportUnknownArgumentType.md)
+- [reportUnknownParameterType](../../docs/diagnostics/reportUnknownParameterType.md)
+- [reportUnknownMemberType](../../docs/diagnostics/reportUnknownMemberType.md)
+- [reportUnknownLambdaType](../../docs/diagnostics/reportUnknownLambdaType.md)
+
+> These dominate strict mode — address by adding annotations, not by silencing. See `pylance-strict-migration`.
+
+### Generics / TypeVar / overloads
+- [reportInvalidTypeArguments](../../docs/diagnostics/reportInvalidTypeArguments.md)
+- [reportMissingTypeArgument](../../docs/diagnostics/reportMissingTypeArgument.md)
+- [reportInvalidTypeVarUse](../../docs/diagnostics/reportInvalidTypeVarUse.md)
+- [reportInconsistentOverload](../../docs/diagnostics/reportInconsistentOverload.md)
+- [reportOverlappingOverload](../../docs/diagnostics/reportOverlappingOverload.md)
+
+> Fix by authoring generics correctly — see `pylance-type-system-patterns`.
+
+### OOP / overrides
+- [reportIncompatibleMethodOverride](../../docs/diagnostics/reportIncompatibleMethodOverride.md)
+- [reportIncompatibleVariableOverride](../../docs/diagnostics/reportIncompatibleVariableOverride.md)
+- [reportImplicitOverride](../../docs/diagnostics/reportImplicitOverride.md)
+- [reportAbstractUsage](../../docs/diagnostics/reportAbstractUsage.md)
+- [reportMissingSuperCall](../../docs/diagnostics/reportMissingSuperCall.md)
+- [reportPropertyTypeMismatch](../../docs/diagnostics/reportPropertyTypeMismatch.md)
+- [reportFunctionMemberAccess](../../docs/diagnostics/reportFunctionMemberAccess.md)
+- [reportPrivateUsage](../../docs/diagnostics/reportPrivateUsage.md)
+- [reportUnsupportedDunderAll](../../docs/diagnostics/reportUnsupportedDunderAll.md)
+
+### TypedDict / type forms
+- [reportTypedDictNotRequiredAccess](../../docs/diagnostics/reportTypedDictNotRequiredAccess.md)
+- [reportInvalidTypeForm](../../docs/diagnostics/reportInvalidTypeForm.md)
+- [reportTypeCommentUsage](../../docs/diagnostics/reportTypeCommentUsage.md)
+
+### Unnecessary / redundant
+- [reportUnnecessaryIsInstance](../../docs/diagnostics/reportUnnecessaryIsInstance.md)
+- [reportUnnecessaryComparison](../../docs/diagnostics/reportUnnecessaryComparison.md)
+- [reportUnnecessaryContains](../../docs/diagnostics/reportUnnecessaryContains.md)
+- [reportUnnecessaryCast](../../docs/diagnostics/reportUnnecessaryCast.md)
+- [reportUnnecessaryTypeIgnoreComment](../../docs/diagnostics/reportUnnecessaryTypeIgnoreComment.md)
+
+### Untyped code
+- [reportUntypedBaseClass](../../docs/diagnostics/reportUntypedBaseClass.md)
+- [reportUntypedClassDecorator](../../docs/diagnostics/reportUntypedClassDecorator.md)
+- [reportUntypedFunctionDecorator](../../docs/diagnostics/reportUntypedFunctionDecorator.md)
+- [reportUntypedNamedTuple](../../docs/diagnostics/reportUntypedNamedTuple.md)
+- [reportMissingParameterType](../../docs/diagnostics/reportMissingParameterType.md)
+
+### Variables / binding
+- [reportUndefinedVariable](../../docs/diagnostics/reportUndefinedVariable.md)
+- [reportUnboundVariable](../../docs/diagnostics/reportUnboundVariable.md)
+- [reportPossiblyUnboundVariable](../../docs/diagnostics/reportPossiblyUnboundVariable.md)
+- [reportUninitializedInstanceVariable](../../docs/diagnostics/reportUninitializedInstanceVariable.md)
+- [reportRedeclaration](../../docs/diagnostics/reportRedeclaration.md)
+- [reportConstantRedefinition](../../docs/diagnostics/reportConstantRedefinition.md)
+- [reportUnhashable](../../docs/diagnostics/reportUnhashable.md)
+
+### Misc
+- [reportAbstractUsage](../../docs/diagnostics/reportAbstractUsage.md) — abstract base usage.
+- [reportAssertAlwaysTrue](../../docs/diagnostics/reportAssertAlwaysTrue.md) — assert on a constant truthy.
+- [reportAssertTypeFailure](../../docs/diagnostics/reportAssertTypeFailure.md) — `assert_type` mismatch.
+- [reportMatchNotExhaustive](../../docs/diagnostics/reportMatchNotExhaustive.md) — non-exhaustive `match`.
+- [reportDeprecated](../../docs/diagnostics/reportDeprecated.md) — use of `@deprecated`.
+- [reportUnusedVariable](../../docs/diagnostics/reportUnusedVariable.md), [reportUnusedFunction](../../docs/diagnostics/reportUnusedFunction.md), [reportUnusedClass](../../docs/diagnostics/reportUnusedClass.md), [reportUnusedExpression](../../docs/diagnostics/reportUnusedExpression.md), [reportUnusedCallResult](../../docs/diagnostics/reportUnusedCallResult.md), [reportUnusedCoroutine](../../docs/diagnostics/reportUnusedCoroutine.md)
+- [reportImplicitStringConcatenation](../../docs/diagnostics/reportImplicitStringConcatenation.md)
+- [reportInvalidStringEscapeSequence](../../docs/diagnostics/reportInvalidStringEscapeSequence.md)
+- [reportInvalidStubStatement](../../docs/diagnostics/reportInvalidStubStatement.md)
+- [reportCallInDefaultInitializer](../../docs/diagnostics/reportCallInDefaultInitializer.md)
+- [reportWildcardImportFromLibrary](../../docs/diagnostics/reportWildcardImportFromLibrary.md) — listed under Import/stub too.
+
+## Note on the deprecated rule list
+
+[../../DIAGNOSTIC_SEVERITY_RULES.md](../../DIAGNOSTIC_SEVERITY_RULES.md) is a **deprecated stub**. Do **not** use it as the rule source — the authoritative live set is this `docs/diagnostics/` directory plus the mode table above.
+
+## Related skills
+
+- **pylance-strict-migration** — addressing the `reportUnknown*` family and raising strictness.
+- **pylance-type-system-patterns** — typing fixes for generics/overload/override rules.
+- **pylance-import-resolution** — fixes for the import/stub rules.
+- **pylance-type-checking-setup** — changing a rule's severity or mode.

--- a/skill/pylance-import-resolution/SKILL.md
+++ b/skill/pylance-import-resolution/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: pylance-import-resolution
+description: Fix unresolved-import and missing-stub errors in Pylance/Pyright. Use for "Import ... could not be resolved", reportMissingImports, reportMissingModuleSource, reportMissingTypeStubs, and configuring extraPaths, autoSearchPaths, stubPath, typeshedPaths, useLibraryCodeForTypes, editable installs, or interpreter selection. Triggers on "unresolved import", "extraPaths", "stub", "py.typed", "editable install", "interpreter", "venv".
+---
+
+# Pylance import resolution
+
+Fixes for `Import "..." could not be resolved` and related import/stub errors. **The single most common Pylance pain point.** For the specific diagnostic rules involved, see `pylance-diagnostics-triage`. For monorepo cross-project paths, see `pylance-workspace-perf`.
+
+## How Pylance resolves imports
+
+Pylance mimics Python's import mechanism for static analysis: it searches a constructed `sys.path` (interpreter site-packages + stdlib + configured paths). If a module isn't on that path, you get `reportMissingImports`. Background: [../../docs/howto/unresolved-imports.md](../../docs/howto/unresolved-imports.md) and the deep-dive in [../../docs/settings/python_analysis_extraPaths.md](../../docs/settings/python_analysis_extraPaths.md).
+
+## Decision tree
+
+1. **Wrong interpreter?** The #1 cause. A selected venv/conda/uv/poetry environment must actually contain the package. Pick/switch interpreters per [../../docs/howto/python-environments.md](../../docs/howto/python-environments.md). Reconcile declared deps: [../../docs/howto/dependency-management.md](../../docs/howto/dependency-management.md).
+2. **Your own code in a non-standard layout (e.g. `src/` layout)?** Add it to `extraPaths`. Glob patterns and ordering: [../../docs/howto/extra-paths-glob-resolution.md](../../docs/howto/extra-paths-glob-resolution.md).
+3. **Third-party lib missing type info?** Install stubs (`pip install types-requests`) or put custom `.pyi` in `stubPath`, or let Pylance infer from source via `useLibraryCodeForTypes`. Override bundled stubs: [../../docs/howto/bundled-stubs.md](../../docs/howto/bundled-stubs.md).
+4. **`pip install -e` not resolvable?** Editable installs (PEP 660): [../../docs/howto/editable-installs.md](../../docs/howto/editable-installs.md).
+5. **Still stuck?** Trace logs: [../../docs/howto/reading-pylance-logs.md](../../docs/howto/reading-pylance-logs.md); root troubleshooting: [../../TROUBLESHOOTING.md](../../TROUBLESHOOTING.md).
+
+## Path & stub settings (one page each)
+
+- [extraPaths](../../docs/settings/python_analysis_extraPaths.md) — additional import-resolution directories
+- [autoSearchPaths](../../docs/settings/python_analysis_autoSearchPaths.md) — auto-detect `src/`
+- [stubPath](../../docs/settings/python_analysis_stubPath.md) — custom `.pyi` location
+- [typeshedPaths](../../docs/settings/python_analysis_typeshedPaths.md) — custom typeshed
+- [useLibraryCodeForTypes](../../docs/settings/python_analysis_useLibraryCodeForTypes.md) — infer types from library source when stubs missing (the type-inference lever)
+- [enableEditableInstalls](../../docs/settings/python_analysis_enableEditableInstalls.md) — resolve PEP 660 on Python 3.13+
+- [importFormat](../../docs/settings/python_analysis_importFormat.md) — absolute vs relative in auto-imports
+
+## Quick fixes users often apply
+
+```jsonc
+// .vscode/settings.json
+{
+  "python.analysis.extraPaths": ["./src", "./lib"]
+}
+```
+
+```python
+# Optional / platform-specific import — suppress the diagnostic
+try:
+    import optional_module  # pyright: ignore[reportMissingImports]
+except ImportError:
+    optional_module = None
+```
+
+## Related skills
+
+- **pylance-diagnostics-triage** — details on `reportMissingImports`, `reportMissingModuleSource`, `reportMissingTypeStubs`, `reportIncompleteStub`, `reportPrivateImportUsage`, `reportImportCycles`.
+- **pylance-workspace-perf** — monorepo/multi-root `extraPaths` and execution environments.
+- **pylance-type-checking-setup** — config-file precedence (why `extraPaths` might be ignored).

--- a/skill/pylance-strict-migration/SKILL.md
+++ b/skill/pylance-strict-migration/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pylance-strict-migration
+description: Move a Python codebase from off/basic to strict type checking incrementally with Pylance/Pyright. Use for per-file "# pyright: strict" comments, per-directory strict arrays in pyrightconfig.json, CI enforcement, and quieting the reportUnknown* rule family. Triggers on "move to strict", "gradual strict adoption", "enable strict mode", "reportUnknownVariableType", "reportUnknownParameterType", "typeEvaluation strict".
+---
+
+# Migrating to strict type checking
+
+A phased path from `off`/`basic` to `strict`. For what individual rules mean, see `pylance-diagnostics-triage`. For the modes themselves, see `pylance-type-checking-setup`.
+
+## The 5-phase strategy
+
+Authoritative walkthrough: [../../docs/howto/gradual-strict-adoption.md](../../docs/howto/gradual-strict-adoption.md). In summary:
+
+1. Start at `basic` workspace-wide; fix the common mistakes (argument/assignment/return, Optional-member access).
+2. Opt individual files into `strict` via the `# pyright: strict` comment at the top of a file.
+3. Promote directories: add them to the `strict` array in `pyrightconfig.json` so whole subtrees are strict.
+4. Quiet the `reportUnknown*` family by adding annotations (not by silencing).
+5. Flip the workspace default to `strict` once most code is clean.
+
+## Per-file / per-directory strict
+
+```python
+# pyright: strict
+```
+
+```jsonc
+// pyrightconfig.json
+{
+  "typeCheckingMode": "basic",
+  "strict": ["src/core", "src/api"],
+  "strictListInference": true,
+  "strictDictionaryInference": true
+}
+```
+
+Per-file/per-directory commentary and common rule suppressions: [../../docs/howto/gradual-strict-adoption.md](../../docs/howto/gradual-strict-adoption.md).
+
+## The reportUnknown* family
+
+Strict mode leans heavily on these. Address them by adding type annotations rather than disabling:
+
+- [reportUnknownVariableType](../../docs/diagnostics/reportUnknownVariableType.md)
+- [reportUnknownArgumentType](../../docs/diagnostics/reportUnknownArgumentType.md)
+- [reportUnknownParameterType](../../docs/diagnostics/reportUnknownParameterType.md)
+- [reportUnknownMemberType](../../docs/diagnostics/reportUnknownMemberType.md)
+- [reportUnknownLambdaType](../../docs/diagnostics/reportUnknownLambdaType.md)
+
+Common culprit: unannotated function returns/params. The `analyzeUnannotatedFunctions` setting controls whether unannotated functions are analyzed at all.
+
+## Strict inference settings (typeEvaluation.*)
+
+These sharpen Pylance's inference and are the levers behind strict-mode noise:
+
+- [strictDictionaryInference](../../docs/settings/python_analysis_typeEvaluation_strictDictionaryInference.md)
+- [strictListInference](../../docs/settings/python_analysis_typeEvaluation_strictListInference.md)
+- [strictSetInference](../../docs/settings/python_analysis_typeEvaluation_strictSetInference.md)
+- [strictParameterNoneValue](../../docs/settings/python_analysis_typeEvaluation_strictParameterNoneValue.md)
+- [analyzeUnannotatedFunctions](../../docs/settings/python_analysis_typeEvaluation_analyzeUnannotatedFunctions.md)
+
+Mode table: [../../docs/settings/python_analysis_typeCheckingMode.md](../../docs/settings/python_analysis_typeCheckingMode.md).
+
+## CI parity
+
+CI must match editor diagnostics or the migration feels broken. Run the Pyright CLI in CI with JSON output / pre-commit / GitHub Action: [../../docs/howto/ci-type-checking.md](../../docs/howto/ci-type-checking.md). Pin `pyrightVersion` to match — [../../docs/settings/python_analysis_pyrightVersion.md](../../docs/settings/python_analysis_pyrightVersion.md).
+
+## Related skills
+
+- **pylance-diagnostics-triage** — per-rule meaning and suppression.
+- **pylance-type-checking-setup** — `typeCheckingMode`, `diagnosticSeverityOverrides`, config precedence.
+- **pylance-type-system-patterns** — annotation patterns that clear unknown-type errors.

--- a/skill/pylance-type-checking-setup/SKILL.md
+++ b/skill/pylance-type-checking-setup/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: pylance-type-checking-setup
+description: Configure Pylance/Pyright type-checking strictness and scope in VS Code. Use when setting typeCheckingMode (off/basic/standard/strict), per-rule diagnosticSeverityOverrides, languageServerMode, pyrightVersion pinning, or reconciling settings.json vs pyrightconfig.json vs pyproject.toml [tool.pyright]. Triggers on "configure pylance", "enable strict type checking", "typeCheckingMode", "diagnosticSeverityOverrides", "pyright config", "settings precedence".
+---
+
+# Pylance type-checking setup & configuration
+
+This skill configures *how strict* Pylance/Pyright is and *how settings are resolved*. For what each diagnostic rule means, see the `pylance-diagnostics-triage` skill. For moving a codebase to strict gradually, see `pylance-strict-migration`.
+
+## The four type-checking modes
+
+`python.analysis.typeCheckingMode` is the baseline strictness preset (default `off`). Each level adds rules on top of the previous:
+
+- **`off`** — No broad type-checking pass; still reports unresolved imports and undefined variables.
+- **`basic`** — Catches common mistakes (argument/assignment/return mismatches, Optional-member access).
+- **`standard`** — Adds more rules on top of `basic`.
+- **`strict`** — The strictest default rule set.
+
+**Read the authoritative mode→rule table** to know exactly which rules each level enables: [../../docs/settings/python_analysis_typeCheckingMode.md](../../docs/settings/python_analysis_typeCheckingMode.md).
+
+## Overriding individual rules without changing mode
+
+Use `python.analysis.diagnosticSeverityOverrides` to raise/lower one rule without shifting the whole mode. Values: `error`, `warning`, `information`, `none`, `true` (= `error`), `false` (= `none`).
+
+```jsonc
+{
+  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingImports": "error",
+    "reportGeneralTypeIssues": "warning",
+    "reportUnknownVariableType": "none"   // keep basic mode but silence one strict-family rule
+  }
+}
+```
+
+Full accepted-values and pyrightconfig interaction: [../../docs/settings/python_analysis_diagnosticSeverityOverrides.md](../../docs/settings/python_analysis_diagnosticSeverityOverrides.md).
+
+## Language server mode
+
+`languageServerMode` (`light`/`default`/`full`) trades features for performance — separate from type-checking strictness. Detail: [../../docs/settings/python_analysis_languageServerMode.md](../../docs/settings/python_analysis_languageServerMode.md).
+
+## Pinning a Pyright version
+
+`python.analysis.pyrightVersion` pins the Pyright version that produces diagnostics, useful for matching CI. `useNearestConfiguration` changes which config file applies per directory. See [../../docs/settings/python_analysis_pyrightVersion.md](../../docs/settings/python_analysis_pyrightVersion.md) and [../../docs/settings/python_analysis_useNearestConfiguration.md](../../docs/settings/python_analysis_useNearestConfiguration.md).
+
+## Config-file precedence & conflicts
+
+Three sources can define settings; precedence and override quirks (why an override seems ignored) are the most common config bug:
+
+- `.vscode/settings.json` — `python.analysis.*`
+- `pyrightconfig.json` — Pyright-native keys (e.g. `typeCheckingMode`, rule names directly)
+- `pyproject.toml` — `[tool.pyright]`
+
+Diagnose precedence and conflicts: [../../docs/howto/settings-troubleshooting.md](../../docs/howto/settings-troubleshooting.md).
+
+## Pylance vs standalone Pyright
+
+Defaults differ between the Pylance extension and a standalone Pyright install (e.g. `typeCheckingMode` `off` vs `standard`, `autoSearchPaths`, `extraPaths`/`PYTHONPATH` handling). When matching editor diagnostics to CLI/CI, reconcile: [../../USING_WITH_PYRIGHT.md](../../USING_WITH_PYRIGHT.md).
+
+## A real example config
+
+[../../testing/single/pyrightconfig.json](../../testing/single/pyrightconfig.json) shows `executionEnvironments` with per-env `extraPaths`, rule severities, and `typeCheckingMode: basic`. The matching VS Code settings: [../../testing/single/.vscode/settings.json](../../testing/single/.vscode/settings.json).
+
+## Related skills
+
+- **pylance-diagnostics-triage** — what each `report*` rule means and how to suppress it.
+- **pylance-strict-migration** — phased path from `off` to `strict`.
+- **pylance-import-resolution** — path/interpreter settings that imports depend on.

--- a/skill/pylance-type-server-protocol/SKILL.md
+++ b/skill/pylance-type-server-protocol/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pylance-type-server-protocol
+description: Reference for the Pylance Type Server Protocol (TSP) — the JSON-RPC protocol for programmatically querying a type server for Python analysis data (snapshots, search paths, import resolution, computed/declared/expected types). Use when building tooling, MCP servers, or editors that speak typeServer/*. Triggers on "Type Server Protocol", "TSP", "typeServer", "type query", "programmatic type analysis".
+---
+
+# Type Server Protocol (TSP)
+
+The **Type Server Protocol** is a JSON-RPC protocol for asking a type server for Python analysis data. A type server maintains the type-analysis state for a workspace and answers requests for: protocol version, snapshots, Python search paths, import resolution, and type queries (computed, declared, expected). TSP methods use the `typeServer/` prefix and reuse LSP data shapes (`Position`, `Range`, string URIs).
+
+## When to use TSP vs LSP
+
+TSP is for tooling that needs *type-level data* beyond what the Language Server Protocol exposes — e.g. computing the declared vs. inferred type at a position, or resolving what a symbol imports to. Use TSP when building an editor, an MCP/AI tool that reasons about types, or a custom analyzer backed by Pylance/Pyright.
+
+## Authoritative artifacts
+
+- [../../docs/tsp/type-server-protocol.md](../../docs/tsp/type-server-protocol.md) — human-readable spec (connection model, version history `0.1.0`–`0.4.1`, multi-connection negotiation).
+- [../../docs/tsp/typeServerProtocol.ts](../../docs/tsp/typeServerProtocol.ts) — the authoritative TypeScript interfaces and request/notification types.
+- [../../docs/tsp/tsp.json](../../docs/tsp/tsp.json) — machine-readable protocol model (all `typeServer/*` methods).
+- [../../docs/tsp/tsp.schema.json](../../docs/tsp/tsp.schema.json) — JSON schema for the model.
+
+## Connection model
+
+A client starts a type server and communicates over stdio on the main JSON-RPC connection; stdout is reserved for protocol messages. Clients synchronize workspace/document state via normal LSP initialization, then send `typeServer/*` requests on the same connection. Full detail: [../../docs/tsp/type-server-protocol.md](../../docs/tsp/type-server-protocol.md).
+
+## Related context
+
+For the existing Pylance MCP-tooling workflow with Copilot (resolving interpreters, listing files, querying diagnostics, applying fixes), see [../../docs/howto/copilot-pylance-workflow.md](../../docs/howto/copilot-pylance-workflow.md).

--- a/skill/pylance-type-system-patterns/SKILL.md
+++ b/skill/pylance-type-system-patterns/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pylance-type-system-patterns
+description: Write and fix Python typing so Pylance/Pyright infers and accepts it — type narrowing (isinstance, is None, TypeGuard/TypeIs, discriminated unions), generics/TypeVar, Protocol, TypedDict, Literal, overloads, and method overrides. Use when authoring annotations or resolving reportInvalidTypeVarUse, reportInvalidTypeArguments, reportMissingTypeArgument, reportInconsistentOverload, reportIncompatibleMethodOverride, reportTypedDictNotRequiredAccess. Triggers on "type narrowing", "TypeGuard", "Protocol", "TypedDict", "overload", "generic", "TypeVar", "discriminated union".
+---
+
+# Python type-system patterns
+
+Authoring typing that Pylance/Pyright infers and accepts. For per-rule meaning, see `pylance-diagnostics-triage`.
+
+## Type narrowing
+
+The full pattern table (isinstance, `is None`, truthiness, `type()`, `in`/`len`, discriminated unions, `TypeGuard` vs `TypeIs`, narrowing in closures): [../../docs/howto/type-narrowing.md](../../docs/howto/type-narrowing.md).
+
+Quick patterns:
+
+```python
+def f(x: int | None) -> int:
+    if x is None:
+        raise ValueError
+    return x + 1          # narrowed to int here
+
+# TypeGuard
+from typing import TypeGuard
+def is_str_list(v: list[object]) -> TypeGuard[list[str]]:
+    return all(isinstance(i, str) for i in v)
+```
+
+## Generics, Protocol, TypedDict, Literal
+
+The in-repo docs have **no dedicated guide** for generics/Protocol — coverage is spread across diagnostic pages. This skill fills that gap with a distilled mini-guide: read [references/generics-and-protocols.md](references/generics-and-protocols.md) first, then drill into the linked diagnostics.
+
+## Overloads
+
+Author overloads so signatures are compatible (not overlapping):
+
+- [reportInconsistentOverload](../../docs/diagnostics/reportInconsistentOverload.md) — overload signatures incompatible with each other.
+- [reportOverlappingOverload](../../docs/diagnostics/reportOverlappingOverload.md) — an overload is shadowed by another.
+
+```python
+from typing import overload
+
+@overload
+def g(x: int) -> int: ...
+@overload
+def g(x: str) -> str: ...
+def g(x: int | str) -> int | str: ...
+```
+
+## Method/variable overrides
+
+Subclass overrides must keep the parent's contract:
+
+- [reportIncompatibleMethodOverride](../../docs/diagnostics/reportIncompatibleMethodOverride.md)
+- [reportIncompatibleVariableOverride](../../docs/diagnostics/reportIncompatibleVariableOverride.md)
+- [reportImplicitOverride](../../docs/diagnostics/reportImplicitOverride.md)
+
+Docstring resolution across overloads / `__init__` / MRO / stub-vs-source: [../../docs/howto/docstring-resolution-order.md](../../docs/howto/docstring-resolution-order.md).
+
+## Type-form and TypedDict access
+
+- [reportInvalidTypeForm](../../docs/diagnostics/reportInvalidTypeForm.md) — a type expression that isn't valid.
+- [reportTypedDictNotRequiredAccess](../../docs/diagnostics/reportTypedDictNotRequiredAccess.md) — accessing a `NotRequired`/`Required` key incorrectly.
+- [reportInvalidTypeVarUse](../../docs/diagnostics/reportInvalidTypeVarUse.md) / [reportInvalidTypeArguments](../../docs/diagnostics/reportInvalidTypeArguments.md) / [reportMissingTypeArgument](../../docs/diagnostics/reportMissingTypeArgument.md) — generic-usage errors.
+
+## Typing-alias & promotion settings
+
+- [deprecateTypingAliases](../../docs/settings/python_analysis_typeEvaluation_deprecateTypingAliases.md) — flag deprecated `typing` aliases (e.g. `List` → `list`).
+- [disableBytesTypePromotions](../../docs/settings/python_analysis_typeEvaluation_disableBytesTypePromotions.md)
+- [enableExperimentalFeatures](../../docs/settings/python_analysis_typeEvaluation_enableExperimentalFeatures.md)
+
+## Related skills
+
+- **pylance-diagnostics-triage** — per-rule meaning and suppression.
+- **pylance-strict-migration** — clearing the `reportUnknown*` family by adding annotations.

--- a/skill/pylance-type-system-patterns/references/generics-and-protocols.md
+++ b/skill/pylance-type-system-patterns/references/generics-and-protocols.md
@@ -1,0 +1,92 @@
+# Generics, Protocol, TypedDict, and Literal
+
+A distilled mini-guide. The Pylance docs corpus has **no standalone page** for generics/Protocol — these topics are covered only via diagnostic pages and the narrowing guide. This reference fills that gap and links back to the authoritative diagnostics.
+
+## TypeVar and generics
+
+`TypeVar` parameterizes a generic. Use it for functions that preserve the argument type, and for generic classes.
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def first(xs: list[T]) -> T:          # return type tracks the element type
+    return xs[0]
+
+class Stack[T]:                      # Python 3.12+ generic class syntax
+    def push(self, x: T) -> None: ...
+```
+
+Constrain or bound a TypeVar:
+
+```python
+T = TypeVar("T", bound=int)           # T must be int or subtype
+T2 = TypeVar("T2", str, bytes)        # T2 is str | bytes
+```
+
+Related diagnostics when generics are misused:
+- [reportInvalidTypeVarUse](../../docs/diagnostics/reportInvalidTypeVarUse.md) — TypeVar declared/used incorrectly.
+- [reportInvalidTypeArguments](../../docs/diagnostics/reportInvalidTypeArguments.md) — wrong type arguments supplied to a generic.
+- [reportMissingTypeArgument](../../docs/diagnostics/reportMissingTypeArgument.md) — a generic used without its type argument.
+
+## Protocol (structural typing)
+
+A `Protocol` defines an interface structurally — a class satisfies it by having the right members, no inheritance required.
+
+```python
+from typing import Protocol
+
+class Closeable(Protocol):
+    def close(self) -> None: ...
+
+def shutdown(c: Closeable) -> None:
+    c.close()
+
+class Resource:                        # implicitly satisfies Closeable
+    def close(self) -> None: ...
+
+shutdown(Resource())                   # OK
+```
+
+`@runtime_checkable` protocols can be used with `isinstance` (only checks attributes exist, not their types).
+
+> The docs surface Protocol indirectly through override/access diagnostics; there is no dedicated guide. The main gotchas Pyright flags: mismatched member signatures in overrides and `reportAttributeAccessIssue`.
+
+Related: [reportIncompatibleMethodOverride](../../docs/diagnostics/reportIncompatibleMethodOverride.md), [reportAttributeAccessIssue](../../docs/diagnostics/reportAttributeAccessIssue.md).
+
+## TypedDict
+
+A `TypedDict` types dict literals with a fixed key set and per-key value types. `NotRequired`/`Required` mark optional/mandatory keys.
+
+```python
+from typing import TypedDict, NotRequired
+
+class User(TypedDict):
+    id: int
+    name: str
+    email: NotRequired[str]
+
+u: User = {"id": 1, "name": "Ann"}
+```
+
+Related diagnostic: [reportTypedDictNotRequiredAccess](../../docs/diagnostics/reportTypedDictNotRequiredAccess.md) — accessing a `NotRequired` key without first checking presence.
+
+## Literal
+
+`Literal` pins a value to a specific constant, enabling discriminated-union narrowing.
+
+```python
+from typing import Literal, overload
+
+Mode = Literal["r", "w"]
+
+def open(path: str, mode: Mode) -> None: ...
+```
+
+`Literal` pairs with `match`/narrowing to discriminate unions — see the narrowing guide: [../../docs/howto/type-narrowing.md](../../docs/howto/type-narrowing.md).
+
+## Further reading
+
+- Type narrowing (the companion pattern to all of the above): [../../docs/howto/type-narrowing.md](../../docs/howto/type-narrowing.md)
+- Deprecation of old `typing` aliases (`List`, `Tuple`, …): [../../docs/settings/python_analysis_typeEvaluation_deprecateTypingAliases.md](../../docs/settings/python_analysis_typeEvaluation_deprecateTypingAliases.md)

--- a/skill/pylance-workspace-perf/SKILL.md
+++ b/skill/pylance-workspace-perf/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pylance-workspace-perf
+description: Control which files Pylance checks and keep it fast. Use for diagnosticMode (openFilesOnly vs workspace), include/exclude/ignore, monorepo/multi-root setup, reducing CPU/memory, reading logs, and notebook/remote (SSH/WSL/container) type checking. Triggers on "whole workspace diagnostics", "diagnosticMode", "pylance slow", "memory", "exclude", "monorepo", "notebook", "SSH", "WSL".
+---
+
+# Pylance workspace scope & performance
+
+Control *which files* Pylance analyzes and *keep it fast*. For import-path config, see `pylance-import-resolution`; for strictness, see `pylance-type-checking-setup`.
+
+## openFilesOnly vs workspace
+
+`diagnosticMode` (default `openFilesOnly`) controls scope. `openFilesOnly` only checks files you open — fast, but you won't see errors elsewhere. `workspace` checks everything — complete, but heavier. Trade-off and how to get whole-workspace diagnostics on demand: [../../docs/howto/workspace-vs-open-files-diagnostics.md](../../docs/howto/workspace-vs-open-files-diagnostics.md). Setting page: [../../docs/settings/python_analysis_diagnosticMode.md](../../docs/settings/python_analysis_diagnosticMode.md).
+
+## File scope settings
+
+- [include](../../docs/settings/python_analysis_include.md) — which paths to analyze.
+- [exclude](../../docs/settings/python_analysis_exclude.md) — paths to skip.
+- [ignore](../../docs/settings/python_analysis_ignore.md) — suppress diagnostics on a path without excluding it.
+- [useDefaultExcludes](../../docs/settings/python_analysis_useDefaultExcludes.md) — the built-in default excludes (`.git`, `venv`, etc.; additive).
+- [excludeLibraryDiagnostics](../../docs/settings/python_analysis_excludeLibraryDiagnostics.md) — hide third-party diagnostics.
+
+## Monorepo / multi-root
+
+Configure execution environments with per-root `extraPaths` and cross-project resolution: [../../docs/howto/monorepo-setup.md](../../docs/howto/monorepo-setup.md). Example config: [../../testing/single/pyrightconfig.json](../../testing/single/pyrightconfig.json).
+
+## Performance
+
+Reduce CPU/memory: indexing limits, excludes, `languageServerMode`, `nodeExecutable`. Guide: [../../docs/howto/performance-tuning.md](../../docs/howto/performance-tuning.md). Key settings:
+
+- [indexing](../../docs/settings/python_analysis_indexing.md), [packageIndexDepths](../../docs/settings/python_analysis_packageIndexDepths.md), [userFileIndexingLimit](../../docs/settings/python_analysis_userFileIndexingLimit.md)
+- [nodeExecutable](../../docs/settings/python_analysis_nodeExecutable.md), [languageServerMode](../../docs/settings/python_analysis_languageServerMode.md)
+
+FAQ on memory tuning: [../../FAQ.md](../../FAQ.md).
+
+## Debugging with logs
+
+Trace logging to diagnose import resolution and settings issues: [../../docs/howto/reading-pylance-logs.md](../../docs/howto/reading-pylance-logs.md).
+
+## Notebooks & remote
+
+- Jupyter notebooks: [../../docs/howto/notebook-troubleshooting.md](../../docs/howto/notebook-troubleshooting.md)
+- SSH/WSL/containers/Codespaces: [../../docs/howto/remote-development.md](../../docs/howto/remote-development.md)
+- Auto-import (indexing-driven): [../../docs/howto/auto-import-guide.md](../../docs/howto/auto-import-guide.md)
+
+## Related skills
+
+- **pylance-import-resolution** — `extraPaths`/interpreter config that imports depend on.
+- **pylance-type-checking-setup** — `languageServerMode` and config precedence.
+- **pylance-diagnostics-triage** — silencing noise via `exclude`/`ignore` vs per-rule severity.


### PR DESCRIPTION
Add a skill/ directory with 7 Claude Code skills for Python type checking. Each skill is a thin, triggered entry point that links into the in-repo docs corpus rather than duplicating it:

- pylance-type-checking-setup: typeCheckingMode, severity overrides, config precedence
- pylance-import-resolution: unresolved imports, stubs, paths, interpreter
- pylance-diagnostics-triage: grouped index of all 76 report* rules
- pylance-strict-migration: phased off->strict adoption
- pylance-type-system-patterns: narrowing, generics, Protocol, TypedDict, overloads
- pylance-workspace-perf: diagnosticMode, scope, monorepo, performance, notebooks/remote
- pylance-type-server-protocol: TSP JSON-RPC reference

Includes a skill/README.md index and a gap-fill generics/Protocol reference under type-system-patterns/references/.