### PR TITLE
Add pylance-type-checking skill for writing typed Python

### DIFF
--- a/skills/pylance-type-checking/README.md
+++ b/skills/pylance-type-checking/README.md
@@ -1,0 +1,62 @@
+# Pylance Type-Checking Skill
+
+A [Claude Code](https://docs.claude.com/en/docs/claude-code) skill that helps you **write Python code that passes Pylance/Pyright type checking** — adding type annotations, fixing `report*` diagnostics in the source, applying type narrowing, using `TYPE_CHECKING` imports and type stubs, and suppressing with `# pyright: ignore`.
+
+This skill is about the Python source you produce. It does **not** cover editor/CI configuration (`.vscode/settings.json`, `pyrightconfig.json`, `languageServerMode`, GitHub Actions) — for that, see the [Pylance settings docs](https://github.com/microsoft/pylance-release/tree/main/docs/settings) and [how-to guides](https://github.com/microsoft/pylance-release/tree/main/docs/howto).
+
+Distilled from the official Pylance documentation in the [pylance-release](https://github.com/microsoft/pylance-release) repo.
+
+## What's inside
+
+```
+pylance-type-checking/
+├── SKILL.md                         # main entry — quick reference + decision flow + write-to conventions
+├── README.md                       # this file
+└── references/
+    ├── type-checking-levels.md     # off/basic/standard/strict: what each catches + write-toward guidance + per-file overrides
+    ├── fixing-type-errors.md       # problem→fix pairs for common report* diagnostics (in the code)
+    ├── type-narrowing.md           # isinstance, is None, TypeGuard/TypeIs, narrowing gotchas
+    ├── typed-imports-and-stubs.md  # types-* stubs, TYPE_CHECKING imports, py.typed, .pyi stubs
+    └── diagnostics-reference.md    # compact lookup table of all report* rules
+```
+
+## Install
+
+### Option A: Copy into your personal skills directory
+
+Copy (or symlink) this folder into your Claude Code skills directory:
+
+```bash
+# macOS / Linux
+cp -R pylance-type-checking ~/.claude/skills/
+
+# or symlink (stays in sync if you clone/update the repo)
+ln -s "$(pwd)/pylance-type-checking" ~/.claude/skills/pylance-type-checking
+```
+
+### Option B: Install for a single project
+
+Copy into the project's `.claude/skills/`:
+
+```bash
+mkdir -p .claude/skills
+cp -R pylance-type-checking .claude/skills/
+```
+
+Restart Claude Code (or reload the session) after installing. The skill appears as `pylance-type-checking` and is auto-suggested when you ask about Python type annotations, narrowing union/optional types, resolving Pylance/Pyright `report*` errors, or what level of type checking to write toward.
+
+## Usage
+
+Just ask naturally — the skill triggers on relevant prompts:
+
+- "Write a function that takes `str | None` and returns `str`, type-safe."
+- "Fix this Pylance `reportOptionalMemberAccess` error."
+- "How do I narrow `str | None`?"
+- "What does strict mode require me to annotate?"
+- "Add type stubs / annotations so this import stops reporting `Unknown`."
+
+You can also invoke it directly with `/pylance-type-checking` (Claude Code slash command).
+
+## Source
+
+Distilled from the official Pylance documentation: <https://github.com/microsoft/pylance-release/tree/main/docs>. For full detail on any topic, the references link back to the original docs.

--- a/skills/pylance-type-checking/SKILL.md
+++ b/skills/pylance-type-checking/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pylance-type-checking
+description: Write Python code that passes Pylance/Pyright type checking — add type annotations, fix report* diagnostics in the source (optional/None, unknown types, missing annotations, generics, return/argument/assignment mismatches), apply type narrowing (isinstance, is None, TypeGuard/TypeIs), use TYPE_CHECKING imports and type stubs, and suppress with # pyright: ignore. Use when writing or reviewing Python type annotations, narrowing union/optional types, resolving Pylance/Pyright type errors, or choosing what level of type checking to write toward.
+---
+
+# Pylance Type Checking
+
+This skill helps you **write Python code that satisfies Pylance/Pyright's type-checking rules.** It is about the Python source you produce — annotations, type narrowing, fixing `report*` errors in the code, and inline suppression — not about configuring the editor or CI.
+
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) is the VS Code Python language server; [Pyright](https://github.com/microsoft/pyright) is its underlying static type checker. Both report the same `report*` diagnostics described here. The rules they enforce are the same rules mypy and other PEP 484 checkers respect, so code written to pass them is portable.
+
+## Quick Reference
+
+- **What each checking level catches** (`off`/`basic`/`standard`/`strict`) and what to write toward → [type-checking-levels.md](references/type-checking-levels.md)
+- **Fix a `report*` type error in the code** → [fixing-type-errors.md](references/fixing-type-errors.md)
+- **Narrow a union/optional** (`is None`, `isinstance`, `TypeGuard`/`TypeIs`) → [type-narrowing.md](references/type-narrowing.md)
+- **Typed imports & type stubs** (`TYPE_CHECKING`, `types-*`, `py.typed`) → [typed-imports-and-stubs.md](references/typed-imports-and-stubs.md)
+- **Look up a specific `report*` rule** → [diagnostics-reference.md](references/diagnostics-reference.md)
+
+## Decision Flow
+
+When writing or fixing typed Python:
+
+1. **Know which level you're writing toward** (`off` → `basic` → `standard` → `strict`). Stricter levels demand more annotations and fewer `Any`s. See [type-checking-levels.md](references/type-checking-levels.md).
+2. **Annotate everything the level requires**: all function parameters and returns, generic type arguments, instance attributes in `__init__`. Avoid bare `Any`.
+3. **Fix errors by fixing the code** — narrow optionals, correct return/argument/assignment types, align override signatures, remove dead code — before suppressing. See [fixing-type-errors.md](references/fixing-type-errors.md).
+4. **Suppress last-resort, inline and scoped**: `# pyright: ignore[ruleName]` on the line, or `cast(T, v)` when you know more than the checker. Use per-file `# pyright: strict` / `# pyright: reportX=false` comments to tighten or relax one file.
+5. **Debug with `reveal_type(x)`** to see exactly what Pylance infers at a point.
+
+## Write-To Conventions
+
+- **Annotate parameters and returns** on every function/method — `reportMissingParameterType` and `reportUnknownParameterType` (strict) require it.
+- **Supply generic arguments** — `list[int]`, not `list`; `dict[str, int]`, not `dict`. `reportMissingTypeArgument` (strict) flags bare generics.
+- **Narrow optionals before use** — `if x is None: ...` then use `x`. Never call `.upper()` on `str | None`. See [type-narrowing.md](references/type-narrowing.md).
+- **Declare instance attributes in `__init__`** — `reportAttributeAccessIssue` (basic) flags attributes not initialized there.
+- **Align override signatures** with the parent — `reportIncompatibleMethodOverride` (standard). Add `@override` for clarity.
+- **Prefer `X | None` narrowing** over `Optional[X]` boilerplate; both are fine, but narrowing is what removes the `None` variant.
+- **Suppress scoped, not broad**: `# pyright: ignore[reportUnknownVariableType]` over bare `# type: ignore` — the scoped form only hides what you intend and lets `reportUnnecessaryTypeIgnoreComment` flag it later for cleanup.
+
+> This skill does not cover editor/CI configuration (`.vscode/settings.json`, `pyrightconfig.json`, `languageServerMode`, GitHub Actions, etc.). For that, see the official [Pylance settings docs](https://github.com/microsoft/pylance-release/tree/main/docs/settings) and [how-to guides](https://github.com/microsoft/pylance-release/tree/main/docs/howto).
+
+## Links to Source Documentation
+
+This skill distills the official Pylance documentation. For full detail, see:
+
+- Pylance docs index: https://github.com/microsoft/pylance-release/blob/main/docs/INDEX.md
+- `typeCheckingMode` reference (what rules each level enables): https://github.com/microsoft/pylance-release/blob/main/docs/settings/python_analysis_typeCheckingMode.md
+- Per-diagnostic rule pages: https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/
+- Pyright diagnostic defaults table: https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults
+- Type narrowing how-to: https://github.com/microsoft/pylance-release/blob/main/docs/howto/type-narrowing.md

--- a/skills/pylance-type-checking/references/diagnostics-reference.md
+++ b/skills/pylance-type-checking/references/diagnostics-reference.md
@@ -1,0 +1,144 @@
+# Diagnostics Reference
+
+A compact lookup of all `report*` diagnostic rules: first-active mode, one-line description, and link to the full per-rule doc. Grouped by category. Rules are supersets across modes (`off` ⊂ `basic` ⊂ `standard` ⊂ `strict`); opt-in rules are enabled only when you set them explicitly.
+
+See [type-checking-levels.md](type-checking-levels.md) for level details and [fixing-type-errors.md](fixing-type-errors.md) for fixes to common rules. For the exact per-level severity table, see [Pyright diagnostic defaults](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults).
+
+> Each rule links to the full Pylance per-rule doc for triggers, examples, and fixes.
+
+## General type compatibility
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportGeneralTypeIssues](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportGeneralTypeIssues.md) | basic | Umbrella: protocol mismatches, `@final` subclassing, covariant TypeVar misuse |
+| [reportArgumentType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportArgumentType.md) | basic | Wrong argument type passed to a function |
+| [reportReturnType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportReturnType.md) | basic | Return value doesn't match declared return type |
+| [reportAssignmentType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportAssignmentType.md) | basic | Assigning wrong type to a variable |
+| [reportCallIssue](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportCallIssue.md) | basic | Generic call/argument problems not covered by more specific rules |
+| [reportIndexIssue](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportIndexIssue.md) | basic | Subscript/index type issues |
+| [reportOperatorIssue](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOperatorIssue.md) | basic | Operator operand type issues |
+| [reportAttributeAccessIssue](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportAttributeAccessIssue.md) | basic | Undefined/typo'd attribute, or uninitialized instance attribute |
+| [reportRedeclaration](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportRedeclaration.md) | basic | Variable redeclared with an incompatible type |
+| [reportUnhashable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnhashable.md) | basic | Using an unhashable value where hashable is required |
+| [reportAssertTypeFailure](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportAssertTypeFailure.md) | basic | `assert_type` actual type doesn't match asserted type |
+| [reportTypedDictNotRequiredAccess](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportTypedDictNotRequiredAccess.md) | basic | Unsafe access to a `NotRequired` TypedDict key |
+
+## Optional / `None` handling (the `reportOptional*` family)
+
+All fire when a possibly-`None` value is used where non-`None` is required. Fix by narrowing — see [type-narrowing.md](type-narrowing.md).
+
+| Rule | First active | Fires when you |
+| ---- | ------------ | -------------- |
+| [reportOptionalMemberAccess](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOptionalMemberAccess.md) | basic | access an attribute (`x.foo`) |
+| [reportOptionalCall](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOptionalCall.md) | basic | call it (`x()`) |
+| [reportOptionalSubscript](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOptionalSubscript.md) | basic | subscript it (`x[0]`) |
+| [reportOptionalIterable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOptionalIterable.md) | basic | iterate it (`for i in x`) |
+| [reportOptionalContextManager](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOptionalContextManager.md) | basic | use as `with x:` |
+| [reportOptionalOperand](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOptionalOperand.md) | basic | use as an operand (`x + 1`) |
+
+## Unknown / untyped symbols (strict)
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportUnknownVariableType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnknownVariableType.md) | strict | Variable has `Unknown` type (often untyped library) |
+| [reportUnknownArgumentType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnknownArgumentType.md) | strict | Argument passed has unknown type |
+| [reportUnknownMemberType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnknownMemberType.md) | strict | Attribute access returns unknown type |
+| [reportUnknownParameterType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnknownParameterType.md) | strict | Function parameter has unknown type |
+| [reportUnknownLambdaType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnknownLambdaType.md) | strict | Lambda parameter/return has unknown type |
+
+## Missing annotations / stubs / imports
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportMissingImports](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMissingImports.md) | off (warning) | Import can't be resolved |
+| [reportMissingModuleSource](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMissingModuleSource.md) | off (warning) | Module resolves but source not found |
+| [reportInvalidTypeForm](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportInvalidTypeForm.md) | off (warning) | Invalid type expression in annotation |
+| [reportUndefinedVariable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUndefinedVariable.md) | off (warning) | Reference to an undefined name |
+| [reportUnboundVariable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnboundVariable.md) | basic | Name used before assignment in its scope |
+| [reportPossiblyUnboundVariable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportPossiblyUnboundVariable.md) | standard | Name possibly unbound on some path |
+| [reportMissingParameterType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMissingParameterType.md) | strict | Function parameter missing annotation |
+| [reportMissingTypeArgument](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMissingTypeArgument.md) | strict | Generic used without type arguments |
+| [reportMissingTypeStubs](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMissingTypeStubs.md) | strict | Imported library has no stubs / `py.typed` |
+| [reportInvalidTypeArguments](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportInvalidTypeArguments.md) | basic | Wrong/missing generic arguments |
+| [reportInvalidTypeVarUse](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportInvalidTypeVarUse.md) | basic | Inconsistent `TypeVar` use |
+| [reportIncompleteStub](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportIncompleteStub.md) | strict | Stub file is incomplete |
+| [reportInvalidStubStatement](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportInvalidStubStatement.md) | strict | Invalid statement in a stub file |
+
+## Inheritance / overrides
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportIncompatibleMethodOverride](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportIncompatibleMethodOverride.md) | standard | Subclass method signature incompatible with parent |
+| [reportIncompatibleVariableOverride](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportIncompatibleVariableOverride.md) | standard | Subclass variable override incompatible with parent |
+| [reportOverlappingOverload](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportOverlappingOverload.md) | standard | Overload signatures overlap |
+| [reportInconsistentOverload](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportInconsistentOverload.md) | basic | Overload signature inconsistent with implementation |
+| [reportFunctionMemberAccess](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportFunctionMemberAccess.md) | standard | Accessing member on a function object |
+| [reportUntypedBaseClass](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUntypedBaseClass.md) | strict | Base class has no type info |
+| [reportAbstractUsage](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportAbstractUsage.md) | basic | Instantiating an abstract class |
+
+## Decorators / classes / typing discipline
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportUntypedFunctionDecorator](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUntypedFunctionDecorator.md) | strict | Function decorator has no type info |
+| [reportUntypedClassDecorator](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUntypedClassDecorator.md) | strict | Class decorator has no type info |
+| [reportUntypedNamedTuple](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUntypedNamedTuple.md) | strict | `NamedTuple` subclass without annotations |
+| [reportTypeCommentUsage](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportTypeCommentUsage.md) | strict | Legacy `# type:` comment used instead of annotations |
+| [reportPrivateUsage](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportPrivateUsage.md) | strict | Using a private (`_`-prefixed) symbol from outside |
+| [reportMatchNotExhaustive](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMatchNotExhaustive.md) | strict | `match` statement doesn't handle all cases |
+| [reportConstantRedefinition](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportConstantRedefinition.md) | strict | `Final`/constant variable reassigned |
+| [reportDeprecated](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportDeprecated.md) | strict | Using a `@deprecated` symbol |
+
+## Unused / dead code (mostly strict)
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportUnusedImport](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedImport.md) | strict | Imported but never used |
+| [reportUnusedVariable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedVariable.md) | strict | Declared but never used |
+| [reportUnusedFunction](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedFunction.md) | strict | Function defined but never used |
+| [reportUnusedClass](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedClass.md) | strict | Class defined but never used |
+| [reportUnusedExpression](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedExpression.md) | basic | Expression statement with no effect |
+| [reportUnusedCoroutine](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedCoroutine.md) | basic | Coroutine not awaited |
+| [reportUnnecessaryCast](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnnecessaryCast.md) | strict | Redundant `cast()` — type already correct |
+| [reportUnnecessaryComparison](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnnecessaryComparison.md) | strict | Redundant comparison — type already narrowed |
+| [reportUnnecessaryContains](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnnecessaryContains.md) | strict | Redundant `in` check |
+| [reportUnnecessaryIsInstance](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnnecessaryIsInstance.md) | strict | Redundant `isinstance` — type already narrowed |
+| [reportDuplicateImport](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportDuplicateImport.md) | strict | Same name imported more than once |
+
+## Imports / modules
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportPrivateImportUsage](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportPrivateImportUsage.md) | basic | Using a symbol not in a package's `__all__` / private re-export |
+| [reportWildcardImportFromLibrary](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportWildcardImportFromLibrary.md) | basic | `from lib import *` |
+| [reportUnsupportedDunderAll](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnsupportedDunderAll.md) | basic | `__all__` with unsupported types |
+
+## Strings
+
+| Rule | First active | What it catches |
+| ---- | ------------ | ---------------- |
+| [reportInvalidStringEscapeSequence](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportInvalidStringEscapeSequence.md) | basic | Invalid escape sequence in a string |
+| [reportImplicitStringConcatenation](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportImplicitStringConcatenation.md) | opt-in | Adjacent string literals implicitly concatenated |
+| [reportAssertAlwaysTrue](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportAssertAlwaysTrue.md) | basic | `assert` with a constant-truthy tuple |
+
+## Opt-in only (never enabled by any mode)
+
+Enable these explicitly via `diagnosticSeverityOverrides` or `pyrightconfig.json` if you want them.
+
+| Rule | What it catches |
+| ---- | --------------- |
+| [reportCallInDefaultInitializer](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportCallInDefaultInitializer.md) | Function call in a default argument (evaluated at def time) |
+| [reportImplicitOverride](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportImplicitOverride.md) | Override without `@override` |
+| [reportImportCycles](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportImportCycles.md) | Circular imports |
+| [reportMissingSuperCall](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportMissingSuperCall.md) | Override missing `super().__init__()` (or parent method) |
+| [reportPropertyTypeMismatch](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportPropertyTypeMismatch.md) | Property getter/setter/deleter type mismatch |
+| [reportUninitializedInstanceVariable](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUninitializedInstanceVariable.md) | Instance variable not assigned in `__init__` |
+| [reportUnnecessaryTypeIgnoreComment](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnnecessaryTypeIgnoreComment.md) | `# type: ignore` / `# pyright: ignore` that suppresses nothing |
+| [reportUnusedCallResult](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportUnusedCallResult.md) | Ignoring the result of a call |
+
+## See Also
+
+- [type-checking-levels.md](type-checking-levels.md) — which levels enable which rules, and per-file overrides
+- [fixing-type-errors.md](fixing-type-errors.md) — concrete fixes for the most common rules
+- Pylance diagnostics directory: https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/
+- Pyright diagnostic defaults table: https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults

--- a/skills/pylance-type-checking/references/fixing-type-errors.md
+++ b/skills/pylance-type-checking/references/fixing-type-errors.md
@@ -1,0 +1,219 @@
+# Fixing Type Errors
+
+Organized by the `report*` diagnostic that fires. Always prefer fixing the code over suppressing; suppress only as a last resort (see [When to suppress](#when-to-suppress-vs-fix) below).
+
+The level column shows when the rule first becomes active. See [type-checking-levels.md](type-checking-levels.md) for level details and [diagnostics-reference.md](diagnostics-reference.md) for the full rule lookup.
+
+## Missing annotations / unknown types
+
+### `reportMissingParameterType` (strict)
+
+A function/method parameter has no type annotation.
+
+```python
+def greet(name):  # Warning: Type of parameter "name" is unknown
+    print(f"Hello, {name}")
+```
+
+**Fix — add the annotation:**
+
+```python
+def greet(name: str) -> None:
+    print(f"Hello, {name}")
+```
+
+### `reportUnknownParameterType` / `reportUnknownLambdaType` (strict)
+
+A parameter's type can't be inferred (often from an untyped call or `Any`). Same fix: add an explicit annotation. If the unknown type originates from an untyped library, see [typed-imports-and-stubs.md](typed-imports-and-stubs.md).
+
+### `reportUnknownVariableType` / `reportUnknownArgumentType` / `reportUnknownMemberType` (strict)
+
+A variable/argument/member access has type `Unknown`, usually because it came from an untyped library or an unannotated function.
+
+**Fix**: add a type annotation at the source, or install stubs for the library (`types-*` packages) or write `.pyi` stubs. See [typed-imports-and-stubs.md](typed-imports-and-stubs.md).
+
+### `reportMissingTypeArgument` (strict)
+
+A generic class or type alias is used without its type arguments.
+
+```python
+# Warning: Type argument expected
+def get_items() -> list:
+    return [1, 2, 3]
+```
+
+**Fix — add the type argument:**
+
+```python
+def get_items() -> list[int]:
+    return [1, 2, 3]
+```
+
+### `reportInvalidTypeArguments` / `reportInvalidTypeVarUse` (basic)
+
+Wrong or inconsistent generic arguments, or misuse of a constrained `TypeVar` (e.g., `Box[int, str]` where one arg is expected). Fix by supplying the correct number/type of generic arguments, or by fixing the `TypeVar` definition (correct bounds, constraints, variance).
+
+## Return / argument / assignment mismatches
+
+### `reportReturnType` (basic)
+
+The returned value doesn't match the declared return type.
+
+```python
+def greet(name: str) -> str:
+    if not name:
+        return None  # 'None' is not assignable to 'str'
+    return f"Hello, {name}"
+```
+
+**Fix — either correct the value or correct the annotation:**
+
+```python
+def greet(name: str) -> str | None:
+    if not name:
+        return None
+    return f"Hello, {name}"
+```
+
+### `reportArgumentType` (basic)
+
+The argument passed to a function doesn't match the parameter's declared type. Fix by passing the correct type, or by widening/narrowing the annotation, or by narrowing the value (see [type-narrowing.md](type-narrowing.md)).
+
+### `reportAssignmentType` (basic)
+
+Assigning a value whose type doesn't match the variable's declared type. Fix by correcting the value or the annotation.
+
+### `reportGeneralTypeIssues` (basic)
+
+Umbrella rule for type incompatibilities not covered by more specific rules — protocol mismatches, subclassing a `@final` class, covariant `TypeVar` misuse, etc. Fix by correcting the annotation or the value to match.
+
+## Optional / `None` handling (the `reportOptional*` family)
+
+All of these fire when you use a possibly-`None` value (`X | None` / `Optional[X]`) in a context that requires a non-`None` value:
+
+| Rule | Fires when you |
+| ---- | -------------- |
+| `reportOptionalMemberAccess` | access an attribute (`x.foo`) |
+| `reportOptionalCall` | call it (`x()`) |
+| `reportOptionalSubscript` | subscript it (`x[0]`) |
+| `reportOptionalIterable` | iterate it (`for i in x`) |
+| `reportOptionalContextManager` | use as `with x:` |
+| `reportOptionalOperand` | use as an operand (`x + 1`) |
+
+**Fix — narrow away `None` first.** This is the single most common type-error fix:
+
+```python
+from typing import Optional
+
+def process(value: Optional[str]) -> str:
+    return value.upper()  # Error: "upper" not known on None
+```
+
+**Fix — narrow with a check:**
+
+```python
+def process(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    return value.upper()  # OK — Pylance knows value is str here
+```
+
+See [type-narrowing.md](type-narrowing.md) for all narrowing patterns (`is None`, `isinstance`, truthiness, `TypeGuard`/`TypeIs`).
+
+## Inheritance / overrides
+
+### `reportIncompatibleMethodOverride` / `reportIncompatibleVariableOverride` (standard)
+
+A subclass override has a signature incompatible with the parent (e.g., extra required params, narrower param type, broader return type). Fix by aligning the override signature to the parent's contract.
+
+### `reportUntypedBaseClass` (strict)
+
+Inheriting from a base class Pylance can't see types for. Fix by installing stubs for that base, adding a `py.typed` marker, or inheriting from a typed base. See [typed-imports-and-stubs.md](typed-imports-and-stubs.md).
+
+### `reportImplicitOverride` (opt-in)
+
+A method overrides a parent method without `@override`. Fix by adding the `@override` decorator (typing/`typing_extensions`).
+
+## Unused / dead code (mostly strict)
+
+| Rule | Fix |
+| ---- | --- |
+| `reportUnusedImport` | remove the import (or prefix with `_` if intentionally unused) |
+| `reportUnusedVariable` | remove the variable, or rename to `_`/`_unused` |
+| `reportUnusedFunction` / `reportUnusedClass` | remove it, or add `__all__` / prefix with `_` |
+| `reportUnusedExpression` | make it an assignment or remove it |
+| `reportUnnecessaryCast` | remove the redundant `cast(...)` — the type was already correct |
+| `reportUnnecessaryComparison` / `reportUnnecessaryIsInstance` / `reportUnnecessaryContains` | remove the redundant check — the type is already narrowed |
+| `reportDuplicateImport` | remove the duplicate import |
+| `reportDeprecated` | replace the deprecated symbol with its replacement |
+
+## Stubs and imports
+
+### `reportMissingTypeStubs` (strict)
+
+An imported library has no `.pyi` stubs or `py.typed` marker. See [typed-imports-and-stubs.md](typed-imports-and-stubs.md) for full fixes (install `types-*` packages, write `.pyi` stubs, or prefer `py.typed` libraries).
+
+### `reportMissingImports` (off)
+
+An import can't be resolved at all. See [typed-imports-and-stubs.md](typed-imports-and-stubs.md) (install the package, `TYPE_CHECKING` imports for circular dependencies).
+
+### `reportMissingModuleSource` (off, warning)
+
+The module resolves but its source can't be found (e.g., installed as a compiled extension). Usually harmless; install stubs to get types.
+
+## Attribute access
+
+### `reportAttributeAccessIssue` (basic)
+
+Accessing an undefined or typo'd attribute, or an instance attribute not initialized in `__init__`.
+
+**Fix — initialize instance variables in `__init__`:**
+
+```python
+class Counter:
+    def __init__(self) -> None:
+        self.count = 0  # declare all instance attributes here
+
+    def increment(self) -> None:
+        self.count += 1
+```
+
+### `reportUninitializedInstanceVariable` (opt-in)
+
+Instance variable declared via annotation but never assigned in `__init__`. Assign it, or use a default.
+
+## When to suppress vs fix
+
+Prefer fixing the code. Suppress only when:
+
+- The code is genuinely dynamic and a static type can't express it.
+- A third-party stub is wrong and you're waiting on an upstream fix.
+- Temporarily unblocking work on a legacy file.
+
+### Suppression options (preferred to least)
+
+1. **`# pyright: ignore[ruleName]`** — scoped to one rule on one line. Preferred.
+   ```python
+   x = dynamic_thing()  # pyright: ignore[reportUnknownVariableType]
+   ```
+2. **`# type: ignore`** — broad, suppresses everything on the line. Avoid unless you must (it suppresses other checkers too and hides future errors).
+3. **`cast(TargetType, value)`** — assert a type without a runtime check. Use when you know more than the type system.
+   ```python
+   from typing import cast
+   items = cast(list[str], raw)
+   ```
+4. **Per-file comment** — `# pyright: reportMissingTypeStubs=false` at the top of a file disables one rule for that whole file. See [type-checking-levels.md](type-checking-levels.md).
+5. **Project-wide** — to disable a rule across the whole project, set it to `none` in `pyrightconfig.json` or `[tool.pyright]` (see the [settings docs](https://github.com/microsoft/pylance-release/blob/main/docs/settings/python_analysis_diagnosticSeverityOverrides.md)).
+
+### `reportUnnecessaryTypeIgnoreComment`
+
+Fires (opt-in) when a `# type: ignore` or `# pyright: ignore` no longer suppresses anything — i.e., the error it was hiding is already fixed. Remove the now-dead comment to keep the codebase clean.
+
+> **Tip**: prefer `# pyright: ignore[ruleName]` over `# type: ignore` so that `reportUnnecessaryTypeIgnoreComment` can later flag it for cleanup, and so you only suppress exactly what you intend.
+
+## See Also
+
+- [Type narrowing](type-narrowing.md) — the fix for almost all `reportOptional*` errors and many `reportArgumentType`/`reportReturnType` errors
+- [Typed imports & stubs](typed-imports-and-stubs.md) — fixes for `reportMissingTypeStubs`, `reportMissingImports`, `reportUnknown*`
+- [Type-checking levels](type-checking-levels.md) — what fires at each level and per-file overrides
+- [Diagnostics reference](diagnostics-reference.md) — full lookup table

--- a/skills/pylance-type-checking/references/type-checking-levels.md
+++ b/skills/pylance-type-checking/references/type-checking-levels.md
@@ -1,0 +1,83 @@
+# Type-Checking Levels: What Code Each Catches
+
+Pylance/Pyright have four strictness levels: `off` → `basic` → `standard` → `strict`. Each stricter level is a **superset** — it enables everything below it plus more rules. This reference tells you what each level flags so you can **write code that passes it**, and how to tighten or relax a single file with inline comments.
+
+> This is about the Python code you write, not editor configuration. To set the project's level or change a rule's severity, configure `pyrightconfig.json` or `[tool.pyright]` in `pyproject.toml` — see the [settings docs](https://github.com/microsoft/pylance-release/blob/main/docs/settings/python_analysis_typeCheckingMode.md).
+
+## The Four Levels
+
+| Level | What it catches |
+| ----- | ----------------- |
+| `off` | Only core problems: unresolved imports, undefined variables, invalid type forms. No broad type-checking pass. |
+| `basic` | Common mistakes: argument/return/assignment mismatches, `None` misuse, general type incompatibilities, invalid TypeVar/generic use. Low false-positive rate. |
+| `standard` | Adds override compatibility, possibly-unbound variables, overlapping overloads, function-member access. |
+| `strict` | Full set: unknown types (from untyped sources), missing annotations/stubs, unnecessary casts & checks, unused symbols, untyped decorators/bases. |
+
+### Representative rules each level turns on
+
+Headline rules per level — see the [full defaults table](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults) for every rule and its exact severity.
+
+- **`off`** — `reportMissingImports`, `reportMissingModuleSource`, `reportInvalidTypeForm`, `reportUndefinedVariable` (all warnings).
+- **`basic`** — `reportReturnType`, `reportArgumentType`, `reportAssignmentType`, `reportGeneralTypeIssues`, `reportCallIssue`, `reportIndexIssue`, `reportOperatorIssue`, the `reportOptional*` family (`reportOptionalMemberAccess`, `reportOptionalCall`, `reportOptionalSubscript`, `reportOptionalIterable`, `reportOptionalContextManager`, `reportOptionalOperand`), `reportAttributeAccessIssue`, `reportInvalidTypeVarUse`, `reportInvalidTypeArguments`, `reportAssertAlwaysTrue`, `reportInvalidStringEscapeSequence`, `reportUnboundVariable`, `reportRedeclaration`, `reportUnusedCoroutine`, `reportPrivateImportUsage`.
+- **`standard`** — adds `reportFunctionMemberAccess`, `reportIncompatibleMethodOverride`, `reportIncompatibleVariableOverride`, `reportOverlappingOverload`, `reportPossiblyUnboundVariable`.
+- **`strict`** — adds the `reportUnknown*` family (`reportUnknownVariableType`, `reportUnknownArgumentType`, `reportUnknownMemberType`, `reportUnknownParameterType`, `reportUnknownLambdaType`), `reportMissingParameterType`, `reportMissingTypeArgument`, `reportMissingTypeStubs`, `reportUntyped*` (`reportUntypedBaseClass`, `reportUntypedFunctionDecorator`, `reportUntypedClassDecorator`, `reportUntypedNamedTuple`), `reportDeprecated`, `reportDuplicateImport`, `reportConstantRedefinition`, `reportMatchNotExhaustive`, `reportPrivateUsage`, `reportUnnecessary*` (`reportUnnecessaryCast`, `reportUnnecessaryComparison`, `reportUnnecessaryIsInstance`), `reportUnused*` (`reportUnusedImport`, `reportUnusedVariable`, `reportUnusedFunction`, `reportUnusedClass`), `reportTypeCommentUsage`.
+- **Never enabled by any level (opt-in only)** — `reportCallInDefaultInitializer`, `reportImplicitOverride`, `reportImplicitStringConcatenation`, `reportImportCycles`, `reportMissingSuperCall`, `reportPropertyTypeMismatch`, `reportUninitializedInstanceVariable`, `reportUnnecessaryTypeIgnoreComment`, `reportUnusedCallResult`.
+
+## Writing Toward Each Level
+
+### `off` — minimal
+Just write valid Python that imports resolve and doesn't reference undefined names. No annotations required, but adding them costs nothing and helps the next levels.
+
+### `basic` — the practical baseline
+- Annotate function parameters and return types (avoids the downstream `reportArgumentType`/`reportReturnType` chain).
+- Narrow `X | None` before using it (`reportOptional*` family). See [type-narrowing.md](type-narrowing.md).
+- Initialize all instance attributes in `__init__` (`reportAttributeAccessIssue`).
+- Don't misuse `TypeVar` or supply wrong generic arguments.
+
+### `standard` — stronger defaults
+- Make subclass overrides signature-compatible with the parent (`reportIncompatibleMethodOverride`/`reportIncompatibleVariableOverride`). Add `@override`.
+- Avoid overlapping overload signatures (`reportOverlappingOverload`).
+- Make sure names are bound on all code paths (`reportPossiblyUnboundVariable`).
+
+### `strict` — heavily typed
+- **Annotate every parameter and return** (`reportMissingParameterType`, `reportUnknownParameterType`).
+- **Supply all generic arguments** — `list[int]`, `dict[str, int]`, never bare `list`/`dict` (`reportMissingTypeArgument`).
+- **Avoid `Any` and `Unknown`** — they trigger `reportUnknownVariableType`/`reportUnknownArgumentType`/`reportUnknownMemberType`. Source unknowns usually come from untyped libraries; install `types-*` stubs. See [typed-imports-and-stubs.md](typed-imports-and-stubs.md).
+- **Inherit from typed bases** (`reportUntypedBaseClass`) and use typed decorators (`reportUntypedFunctionDecorator`/`reportUntypedClassDecorator`).
+- **Remove dead code** — unused imports/vars/functions/classes, redundant `cast()` and `isinstance` (`reportUnused*`, `reportUnnecessary*`).
+- **Don't use legacy `# type:` comments** — use real annotations (`reportTypeCommentUsage`).
+- **Cover all `match` cases** (`reportMatchNotExhaustive`).
+
+## Tightening or Relaxing a Single File (inline comments)
+
+You can override the project level for one file with a comment at the top of the file — no config change needed:
+
+| Comment | Effect |
+| ------- | ------ |
+| `# pyright: strict` | Apply strict to this file only (good for fully-typed files) |
+| `# pyright: basic` | Use basic for this file (relax a stricter project default) |
+| `# pyright: reportMissingImports=false` | Disable one rule for this file |
+| `# pyright: reportUnknownVariableType=warning` | Change one rule's severity for this file |
+
+```python
+# pyright: strict
+
+from typing import Optional
+
+def process(name: str, count: int) -> Optional[str]:
+    if count <= 0:
+        return None
+    return name * count
+```
+
+This is the incremental path to strictness: keep the project at `basic`/`standard` and opt individual files into `# pyright: strict` as they're fully annotated, then eventually raise the project default. New code in a strict-by-default project can be marked `# pyright: basic` temporarily while it's being brought up to standard.
+
+> Per-file comments override both `pyrightconfig.json` and editor settings for that file. To change a rule's severity project-wide, set it in `pyrightconfig.json`/`[tool.pyright]` — see the [settings docs](https://github.com/microsoft/pylance-release/blob/main/docs/settings/python_analysis_diagnosticSeverityOverrides.md).
+
+## See Also
+
+- [Fixing type errors](fixing-type-errors.md) — what to change in the code when a `report*` rule fires
+- [Type narrowing](type-narrowing.md) — the fix for `reportOptional*` and many `reportArgumentType`/`reportReturnType` errors
+- [Typed imports & stubs](typed-imports-and-stubs.md) — fixing `reportMissingTypeStubs` and `reportUnknown*` from untyped libraries
+- [Diagnostics reference](diagnostics-reference.md) — full lookup table
+- Full `typeCheckingMode` doc: https://github.com/microsoft/pylance-release/blob/main/docs/settings/python_analysis_typeCheckingMode.md

--- a/skills/pylance-type-checking/references/type-narrowing.md
+++ b/skills/pylance-type-checking/references/type-narrowing.md
@@ -1,0 +1,271 @@
+# Type Narrowing
+
+Pylance uses **type narrowing** to track how a variable's type changes through your code. When you see type errors on variables with union types (`str | None`, `int | str`), type narrowing is usually the fix — use a conditional check to tell Pylance which variant you have.
+
+This is the single most common fix for the `reportOptional*` family and many `reportArgumentType`/`reportReturnType` errors. See [fixing-type-errors.md](fixing-type-errors.md).
+
+## The Basic Idea
+
+```python
+from typing import Optional
+
+def process(value: Optional[str]) -> str:
+    # value is str | None here
+    return value.upper()  # Error: "upper" is not a known attribute of None
+```
+
+**Fix — narrow with a check:**
+
+```python
+def process(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    # After the check, Pylance knows value is str
+    return value.upper()  # OK
+```
+
+Narrowing works in both branches:
+
+```python
+def describe(val: int | str):
+    if isinstance(val, int):
+        print(val + 1)      # OK — val is int
+    else:
+        print(val.upper())  # OK — val is str
+```
+
+## Patterns
+
+### Check for `None`
+
+The most common case — narrowing `Optional[X]` (which is `X | None`):
+
+```python
+if x is not None:      # Preferred
+    ...
+
+if x is None:
+    return             # Early return narrows x to non-None after this line
+
+assert x is not None   # Narrows x to non-None from here onward
+```
+
+### `isinstance` checks
+
+Narrow a union to a specific class:
+
+```python
+def handle(event: KeyEvent | MouseEvent | CloseEvent):
+    if isinstance(event, KeyEvent):
+        print(event.key)        # event is KeyEvent
+    elif isinstance(event, MouseEvent):
+        print(event.x, event.y) # event is MouseEvent
+    else:
+        print("closing")        # event is CloseEvent
+```
+
+`isinstance` also works with tuples of types: `if isinstance(val, (int, float)):`.
+
+### Truthiness checks
+
+```python
+def greet(name: str | None):
+    if name:  # narrows to str (excludes None and "")
+        print(f"Hello, {name}")
+```
+
+> **Note**: truthiness narrowing for numerics is limited — `if val:` on `float | None` only narrows away `None` in the positive branch, because `0.0` is also falsy.
+
+### `type()` checks (exact type, not subclasses)
+
+```python
+if type(val) is int:
+    print(val + 1)  # val is exactly int, not a subclass
+```
+
+### Discriminated unions (TypedDict / Literal field)
+
+```python
+from typing import Literal, TypedDict
+
+class Dog(TypedDict):
+    kind: Literal["dog"]
+    bark_volume: int
+
+class Cat(TypedDict):
+    kind: Literal["cat"]
+    purr_frequency: float
+
+Pet = Dog | Cat
+
+def describe(pet: Pet):
+    if pet["kind"] == "dog":
+        print(pet["bark_volume"])     # pet is Dog
+    else:
+        print(pet["purr_frequency"])  # pet is Cat
+```
+
+### `in` / `not in`
+
+```python
+from typing import Literal
+
+def handle_status(status: Literal["ok", "error", "pending"]):
+    if status in ("ok", "pending"):
+        print("not an error")  # status is Literal["ok", "pending"]
+```
+
+`in` also narrows TypedDict key access: `if "name" in d:` makes `d["name"]` safe.
+
+### `len()` on tuples
+
+```python
+def process(val: tuple[int] | tuple[int, str]):
+    if len(val) == 2:
+        print(val[1].upper())  # val is tuple[int, str]
+```
+
+### `callable()`
+
+```python
+if callable(x):
+    x()  # x is a callable
+```
+
+## Supported Type Guards
+
+| Pattern | Narrows both `if`/`else`? |
+| ------- | ------------------------- |
+| `x is None` / `x is not None` | Yes |
+| `isinstance(x, T)` | Yes |
+| `issubclass(x, T)` | Yes |
+| `type(x) is T` / `type(x) == T` | Yes |
+| `x is C` (class identity) | Yes |
+| Truthiness (`if x:`) | Partial (falsy values overlap) |
+| `x == L` (literal comparison) | Depends on type |
+| `x in collection` | Yes |
+| `S in D` (TypedDict key check) | Yes |
+| `len(x) == L` (tuple length) | Yes |
+| `x.field is/== V` (discriminator) | Yes |
+| `callable(x)` | Yes |
+| Aliased conditions (`is_valid = x is not None; if is_valid:`) | Yes |
+| User-defined `TypeGuard` / `TypeIs` | See below |
+
+Full list: [Pyright Type Guards](https://microsoft.github.io/pyright/#/type-concepts-advanced?id=type-guards).
+
+## Custom Type Guards (`TypeGuard` and `TypeIs`)
+
+When built-in narrowing isn't enough, define a guard function.
+
+### `TypeIs` (Python 3.13+ / `typing_extensions`) — preferred
+
+Narrows in **both** `if` and `else` branches:
+
+```python
+from typing import TypeIs  # or typing_extensions.TypeIs
+
+def is_str(val: object) -> TypeIs[str]:
+    return isinstance(val, str)
+
+def process(val: int | str):
+    if is_str(val):
+        print(val.upper())  # val is str
+    else:
+        print(val + 1)      # val is int
+```
+
+### `TypeGuard` (Python 3.10+ / `typing_extensions`)
+
+Narrows **only** the `if` branch — use when the narrowed type isn't a true subtype:
+
+```python
+from typing import TypeGuard
+
+def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
+    return all(isinstance(item, str) for item in val)
+
+def process(val: list[object]):
+    if is_str_list(val):
+        print(val[0].upper())  # val is list[str]
+    # else: val is still list[object] (not narrowed)
+```
+
+> **When to use which**: prefer `TypeIs` when possible (narrows both branches). Use `TypeGuard` when the output type isn't a true narrowing of the input (e.g., `list[object]` → `list[str]`).
+
+## Why Narrowing Might Not Work
+
+### Narrowing resets after reassignment
+
+```python
+def process(val: str | None):
+    if val is not None:
+        val = some_function()  # type is now some_function's return type
+        print(val.upper())     # may error — narrowing was reset
+```
+
+### Narrowing in closures depends on mutation
+
+Pyright retains narrowing for variables captured by closures **only if** it can prove the variable isn't reassigned after the closure is defined and doesn't use `nonlocal`/`global`. If either is violated, the narrowed type is lost:
+
+```python
+def process_broken(val: str | None):
+    if val is not None:
+        def inner():
+            print(val.upper())  # Error — val is reassigned below
+        val = None               # reassignment after closure definition
+        inner()
+```
+
+**Fix — capture the narrowed value in a local before the closure:**
+
+```python
+def process_safe(val: str | None):
+    if val is not None:
+        captured = val  # captured is str (narrowed, not reassigned)
+        def inner():
+            print(captured.upper())  # OK
+        val = None
+        inner()
+```
+
+### Unsupported expression forms
+
+Narrowing only works on simple names, member-access chains (`a.b.c`), integer subscripts (`a[0]`), and string subscripts (`a["key"]`). Results of method calls or arithmetic are not narrowed.
+
+### `assert` vs `if`
+
+- `assert x is not None` — narrows from that line forward (good for preconditions). Note: disabled under `python -O`.
+- `if x is not None:` — narrows within the `if` block only.
+
+## Narrowing `Any`
+
+`isinstance` narrows `Any` to the checked type — the most common way to work with `Any` safely:
+
+```python
+from typing import Any
+
+def process(data: Any):
+    if isinstance(data, dict):
+        for key in data:  # data is dict
+            print(key)
+```
+
+## Debugging Narrowing
+
+Use `reveal_type(x)` to see exactly what Pylance thinks the type is at a given point:
+
+```python
+def process(val: str | None):
+    if val is not None:
+        reveal_type(val)   # info: str
+        ...
+```
+
+`reveal_type` is a Pyright/Pylance built-in with no runtime effect (it errors at type-check time, printing the type). Remove it after debugging.
+
+## See Also
+
+- [Fixing type errors](fixing-type-errors.md) — which `report*` rules narrowing resolves
+- [Typed imports & stubs](typed-imports-and-stubs.md) — when the unknown type comes from an untyped library
+- Full how-to: https://github.com/microsoft/pylance-release/blob/main/docs/howto/type-narrowing.md
+- Pyright type narrowing spec: https://microsoft.github.io/pyright/#/type-concepts-advanced?id=type-narrowing

--- a/skills/pylance-type-checking/references/typed-imports-and-stubs.md
+++ b/skills/pylance-type-checking/references/typed-imports-and-stubs.md
@@ -1,0 +1,118 @@
+# Typed Imports & Type Stubs
+
+Several `report*` errors trace back to imports: a library has no type stubs (`reportMissingTypeStubs`) or returns `Unknown` types (`reportUnknown*`), or an import can't resolve at all (`reportMissingImports`). This reference covers what to do **in your code and project dependencies** — not editor configuration.
+
+## `reportMissingTypeStubs` (strict)
+
+Fires when an imported library has no `.pyi` stub files or `py.typed` marker, so Pylance can't infer precise types from it.
+
+```python
+import some_library  # Warning: Stub file not found for "some_library"
+```
+
+### Fix — install a stub package as a dev dependency
+
+Many popular libraries have separate `types-*` or `*-stubs` packages on PyPI:
+
+```bash
+pip install types-requests types-PyYAML types-toml
+# AWS SDK stubs (service-scoped):
+pip install 'boto3-stubs[s3,ec2]'
+```
+
+**Keep stub versions aligned** with the library they describe — mismatched versions cause false errors:
+
+```bash
+pip install requests==2.31.0 types-requests==2.31.0
+```
+
+Diagnose mismatches: `pip list | grep -E 'types-|stubs'` and compare versions against the library.
+
+### Fix — prefer `py.typed` libraries
+
+Libraries that ship their own type annotations include a `py.typed` marker (PEP 561). When choosing a dependency, prefer one that's `py.typed` — no stub package needed and the types stay in sync with the implementation.
+
+### Fix — write `.pyi` stubs for untyped dependencies
+
+If no stub package exists and the library isn't `py.typed`, hand-write `.pyi` stub files declaring the symbols you use. Place them in a `typings/` directory (or wherever `stubPath` points) following PEP 561 partial-stub-package layout:
+
+```
+typings/
+└── my_library/
+    └── __init__.pyi
+```
+
+```python
+# typings/my_library/__init__.pyi
+def do_thing(x: int) -> str: ...
+```
+
+### Fix — suppress the rule for that import
+
+If none of the above fit (e.g., a deliberately dynamic library), suppress just this line or relax the rule for the file. It's strict-only and often noisy with untyped dependencies:
+
+```python
+import some_dynamic_lib  # pyright: ignore[reportMissingTypeStubs]
+```
+
+## `reportUnknown*` (strict)
+
+`reportUnknownVariableType`/`reportUnknownArgumentType`/`reportUnknownMemberType`/`reportUnknownParameterType` fire when a type is `Unknown` — usually because it flowed from an untyped library or an unannotated function call.
+
+**Fix at the source**: annotate the function whose return is `Unknown`, or install stubs / write `.pyi` for the library producing it. Don't paper over it with `# pyright: ignore` unless the source is genuinely dynamic.
+
+```python
+import untyped_lib
+
+result = untyped_lib.compute()  # reportUnknownVariableType
+# Fix: install types-untyped_lib, or write a typings/untyped_lib/__init__.pyi
+```
+
+## `reportMissingImports` (off)
+
+Fires when an import can't be resolved at all.
+
+### The package isn't installed
+
+```bash
+pip install the_package
+```
+
+### Circular imports — use `TYPE_CHECKING`
+
+Imports only needed for annotations often cause circular imports. Guard them under `TYPE_CHECKING` and use **string annotations** (or `from __future__ import annotations`) so they aren't evaluated at runtime:
+
+```python
+from __future__ import annotations  # makes all annotations strings
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import User  # only imported by the type checker, not at runtime
+
+def process(user: User) -> None:  # safe — annotation is a string at runtime
+    ...
+```
+
+`from __future__ import annotations` is the simplest fix: every annotation becomes a string literal, so forward references and `TYPE_CHECKING`-only imports never execute at runtime. Without it, use explicit string annotations: `def process(user: "User") -> None:`.
+
+### `reportMissingModuleSource` (off, warning)
+
+The module resolves but its source can't be found (e.g., a compiled extension, or a module that only ships stubs). Usually harmless — install stubs to get rich types.
+
+## Generated / dynamic code
+
+For generated code (Protobuf, Django models, dataclass/attrs/Pydantic synthesized members) Pylance can't analyze statically, the code-level options are:
+
+- `# pyright: ignore` at the top of the generated file — suppresses all diagnostics for that file while keeping imports resolvable.
+- Hand-write `.pyi` stubs declaring the synthesized members (e.g., the dataclass fields).
+
+See the [generated code how-to](https://github.com/microsoft/pylance-release/blob/main/docs/howto/generated-code.md) for framework-specific notes (Django, Protobuf, FastAPI/Pydantic, SQLAlchemy, attrs/dataclasses).
+
+## See Also
+
+- [Fixing type errors](fixing-type-errors.md) — `reportUnknown*` and `reportMissingTypeArgument` fixes
+- [Type-checking levels](type-checking-levels.md) — which levels flag stub/import issues
+- [Type narrowing](type-narrowing.md) — narrowing `Any` with `isinstance`
+- Bundled stubs how-to: https://github.com/microsoft/pylance-release/blob/main/docs/howto/bundled-stubs.md
+- Unresolved imports how-to: https://github.com/microsoft/pylance-release/blob/main/docs/howto/unresolved-imports.md


### PR DESCRIPTION
A Claude Code skill that helps write Python code conforming to Pylance/Pyright type-checking rules: choosing the right checking level, fixing report* diagnostics in the source, type narrowing, typed imports and stubs, and inline suppression. Focused on the Python source produced, not editor/CI configuration.